### PR TITLE
Reame functions, adapt to `HerbSpecification.jl`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,13 @@ version = "0.1.0"
 
 [deps]
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
-HerbData = "495a3ad3-8034-41b3-a087-aacf2fd71098"
 HerbGrammar = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
+HerbSpecification = "6d54aada-062f-46d8-85cf-a1ceaf058a06"
 
 [compat]
-julia = "1.8"
-HerbData = "0.1.1"
-HerbGrammar = "0.1.0"
 HerbCore = "0.1.1"
+HerbGrammar = "0.1.0"
+julia = "1.8"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/HerbInterpret.jl
+++ b/src/HerbInterpret.jl
@@ -1,8 +1,8 @@
 module HerbInterpret
 
 using HerbCore
-using HerbData
 using HerbGrammar
+using HerbSpecification
 
 include("interpreter.jl")
 
@@ -11,6 +11,5 @@ export
     interpret,
 
     execute_on_input
-
 
 end # module HerbInterpret

--- a/src/HerbInterpret.jl
+++ b/src/HerbInterpret.jl
@@ -9,10 +9,8 @@ include("interpreter.jl")
 export 
     SymbolTable,
     interpret,
-    test_examples,
-    test_all_examples,
-    test_with_input,
-    execute_on_examples
+
+    execute_on_input
 
 
 end # module HerbInterpret

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -1,5 +1,6 @@
+using Base: depwarn
 """
-    test_all_examples(tab::SymbolTable, expr::Any, examples::Vector{Example})::Vector{Bool}
+    test_all_examples(tab::SymbolTable, expr::Any, examples::Vector{IOExample})::Vector{Bool}
 
 Runs the interpreter on all examples with the given input table and expression. 
 The symbol table defines everything (functions, symbols) that are not input variables to the program to be synthesised.
@@ -7,27 +8,32 @@ Returns a list of true/false values indicating if the expression satisfies the c
 WARNING: This function throws exceptions that are caused in the given expression.
 These exceptions have to be handled by the caller of this function.
 """
-function test_all_examples(tab::SymbolTable, expr::Any, examples::Vector{Example})::Vector{Bool}
+function test_all_examples(tab::SymbolTable, expr::Any, examples::Vector{IOExample})::Vector{Bool}
+    depwarn("`test_all_examples` is deprecated and should no longer be used.", :test_all_examples)
+    throw(ErrorException("`test_all_examples` has been deprecated and should not be used."))
+
     outcomes = Vector{Bool}(undef, length(examples))
     for example ∈ filter(e -> e isa IOExample, examples)
-        push!(outcomes, example.out == test_with_input(tab, expr, example.in))
+        push!(outcomes, example.out == execute_on_input(tab, expr, example.in))
     end
     return outcomes
 end
 
-
 """
-    test_examples(tab::SymbolTable, expr::Any, examples::Vector{Example})::Bool
+    test_examples(tab::SymbolTable, expr::Any, examples::Vector{IOExample})::Bool
 
 Evaluates all examples and returns true iff all examples pass.
 Shortcircuits as soon as an example is found for which the program doesn't work. 
 Returns false if one of the examples produces an error.
 """
-function test_examples(tab::SymbolTable, expr::Any, examples::Vector{Example})::Bool
+function test_examples(tab::SymbolTable, expr::Any, examples::Vector{IOExample})::Bool
+    depwarn("`test_examples` is deprecated and should no longer be used.", :test_examples)
+    throw(ErrorException("`test_examples` has been deprecated and should not be used."))
+
     for example ∈ filter(e -> e isa IOExample, examples)
         try 
-            output = test_with_input(tab, expr, example.in)
-            if output ≠ test_with_input(tab, expr, example.in)
+            output = execute_on_input(tab, expr, example.in)
+            if output ≠ execute_on_input(tab, expr, example.in)
                 return false
             end
         catch
@@ -39,13 +45,13 @@ end
 
 
 """
-    test_with_input(tab::SymbolTable, expr::Any, input::Dict)
+    exec_on_input(tab::SymbolTable, expr::Any, input::Dict)
 
 Interprets an expression or symbol with the given symboltable and the input.
 WARNING: This function throws exceptions that are caused in the given expression.
 These exceptions have to be handled by the caller of this function.
 """
-function test_with_input(tab::SymbolTable, expr::Any, input::Dict)
+function execute_on_input(tab::SymbolTable, expr::Any, input::Dict)::Any
     # Add input variable values
     symbols = merge(tab, input)
     return interpret(symbols, expr)
@@ -53,23 +59,26 @@ end
 
 
 """
-    execute_on_examples(tab::SymbolTable, expr::Any, example_inputs::Vector{Dict{Symbol, Any}})::Vector{Any}
+    execute_on_examples(tab::SymbolTable, expr::Any, inputs::Vector{Dict{Symbol, Any}})::Vector{Any}
 
 Executes a given expression on a set of inputs and returns the respective outputs.
 WARNING: This function throws exceptions that are caused in the given expression.
 These exceptions have to be handled by the caller of this function.
 """
-function execute_on_examples(tab::SymbolTable, expr::Any, example_inputs::Vector{Dict{Symbol, Any}})::Vector{Any}
-    return [test_with_input(tab, expr, example) for example in example_inputs]
+function execute_on_input(tab::SymbolTable, expr::Any, input::Vector{Dict{Symbol, Any}})::Vector{Any}
+    return [execute_on_input(tab, expr, example) for example in example_inputs]
 end
 
 
 """
-    evaluate_program(program::RuleNode, examples::Vector{<:Example}, grammar::Grammar, evaluation_function::Function)
+    evaluate_program(program::RuleNode, examples::Vector{<:IOExample}, grammar::Grammar, evaluation_function::Function)
 
 Runs a program on the examples and returns tuples of actual desired output and the program's output
 """
-function evaluate_program(program::RuleNode, examples::Vector{<:Example}, grammar::Grammar, evaluation_function::Function)
+function evaluate_program(program::RuleNode, examples::Vector{<:IOExample}, grammar::Grammar, evaluation_function::Function)
+    depwarn("`evaluate_program` is deprecated and should no longer be used. Please use HerbSearch.evaluate instead.", :evaluate_program)
+    throw(ErrorException("`evaluate_program` has been deprecated and should not be used."))
+
     results = Tuple{<:Number,<:Number}[]
     expression = rulenode2expr(program, grammar)
     symbol_table = SymbolTable(grammar)

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -10,7 +10,6 @@ These exceptions have to be handled by the caller of this function.
 """
 function test_all_examples(tab::SymbolTable, expr::Any, examples::Vector{IOExample})::Vector{Bool}
     depwarn("`test_all_examples` is deprecated and should no longer be used.", :test_all_examples)
-    throw(ErrorException("`test_all_examples` has been deprecated and should not be used."))
 
     outcomes = Vector{Bool}(undef, length(examples))
     for example ∈ filter(e -> e isa IOExample, examples)
@@ -28,7 +27,6 @@ Returns false if one of the examples produces an error.
 """
 function test_examples(tab::SymbolTable, expr::Any, examples::Vector{IOExample})::Bool
     depwarn("`test_examples` is deprecated and should no longer be used.", :test_examples)
-    throw(ErrorException("`test_examples` has been deprecated and should not be used."))
 
     for example ∈ filter(e -> e isa IOExample, examples)
         try 
@@ -89,7 +87,6 @@ Runs a program on the examples and returns tuples of actual desired output and t
 """
 function evaluate_program(program::RuleNode, examples::Vector{<:IOExample}, grammar::Grammar, evaluation_function::Function)
     depwarn("`evaluate_program` is deprecated and should no longer be used. Please use HerbSearch.evaluate instead.", :evaluate_program)
-    throw(ErrorException("`evaluate_program` has been deprecated and should not be used."))
 
     results = Tuple{<:Number,<:Number}[]
     expression = rulenode2expr(program, grammar)
@@ -180,13 +177,6 @@ function interpret(tab::SymbolTable, ex::Expr)
         else
             return interpret(tab, args[3])
         end
-    elseif ex.head == :while
-        result = nothing
-
-        while interpret(tab, ex.args[1])
-            result = interpret(tab, ex.args[2])
-        end
-        return result
     else
         error("Expression type not supported")
     end

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -45,13 +45,13 @@ end
 
 
 """
-    exec_on_input(tab::SymbolTable, expr::Any, input::Dict)
+    execute_on_input(tab::SymbolTable, expr::Any, input::Dict)
 
 Interprets an expression or symbol with the given symboltable and the input.
 WARNING: This function throws exceptions that are caused in the given expression.
 These exceptions have to be handled by the caller of this function.
 """
-function execute_on_input(tab::SymbolTable, expr::Any, input::Dict)::Any
+function execute_on_input(tab::SymbolTable, expr::Any, input::Dict{Symbol, <:Any})::Any
     # Add input variable values
     symbols = merge(tab, input)
     return interpret(symbols, expr)
@@ -59,14 +59,26 @@ end
 
 
 """
-    execute_on_examples(tab::SymbolTable, expr::Any, inputs::Vector{Dict{Symbol, Any}})::Vector{Any}
+    execute_on_input(tab::SymbolTable, expr::Any, inputs::Vector{Dict{Symbol, Any}})::Vector{Any}
 
 Executes a given expression on a set of inputs and returns the respective outputs.
 WARNING: This function throws exceptions that are caused in the given expression.
 These exceptions have to be handled by the caller of this function.
 """
 function execute_on_input(tab::SymbolTable, expr::Any, input::Vector{Dict{Symbol, Any}})::Vector{Any}
-    return [execute_on_input(tab, expr, example) for example in example_inputs]
+    return [execute_on_input(tab, expr, example) for example in input]
+end
+
+function execute_on_input(grammar::Grammar, program::RuleNode, input::Vector{Dict{Symbol, Any}})::Vector{Any}
+    expression = rulenode2expr(program, grammar)
+    symboltable = SymbolTable(grammar)
+    return execute_on_input(symboltable, expression, input)
+end
+
+function execute_on_input(grammar::Grammar, program::RuleNode, input::Dict{Symbol, Any})::Any
+    expression = rulenode2expr(program, grammar)
+    symboltable = SymbolTable(grammar)
+    return execute_on_input(symboltable, expression, input)
 end
 
 

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -181,17 +181,9 @@ function interpret(tab::SymbolTable, ex::Expr)
             return interpret(tab, args[3])
         end
     elseif ex.head == :while
-        max_iterations = 1000
         result = nothing
 
-        for i in 1:max_iterations # limit iterations to 1000
-            if !interpret(tab, ex.args[1])
-                break
-            end
-            if i == max_iterations
-                error("Exceeded maximum number of iterations in while-loop.")
-            end
-            
+        while interpret(tab, ex.args[1])
             result = interpret(tab, ex.args[2])
         end
         return result

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -159,6 +159,21 @@ function interpret(tab::SymbolTable, ex::Expr)
         else
             return interpret(tab, args[3])
         end
+    elseif ex.head == :while
+        max_iterations = 1000
+        result = nothing
+
+        for i in 1:max_iterations # limit iterations to 1000
+            if !interpret(tab, ex.args[1])
+                break
+            end
+            if i == max_iterations
+                error("Exceeded maximum number of iterations in while-loop.")
+            end
+            
+            result = interpret(tab, ex.args[2])
+        end
+        return result
     else
         error("Expression type not supported")
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,17 +3,17 @@ using Test
 
 @testset "HerbInterpret.jl" begin
     # Write your tests here. 
-    @testset "Simple test_with_input (x + 2)" begin
+    @testset "Simple execute_on_input (x + 2)" begin
         tab = Dict{Symbol,Any}(:+ => +)
         input_dict = Dict(:x => 3)
-        @test test_with_input(tab, :(x + 2), input_dict) == 5
+        @test execute_on_input(tab, :(x + 2), input_dict) == 5
     end
 
-    @testset "Simple test_with_input (x * x + 2)" begin
+    @testset "Simple execute_on_input (x * x + 2)" begin
         tab = Dict{Symbol,Any}(:+ => +, :* => *)
         input = 3
         f(x) = x * x + 2
         input_dict = Dict(:x => input,:f => f)
-        @test test_with_input(tab, :(f(x)), input_dict) == f(input)
+        @test execute_on_input(tab, :(f(x)), input_dict) == f(input)
     end
 end


### PR DESCRIPTION
- `test_with_input` to `execute_on_input` (see #10)
- dependencies now aligned with HerbSpecification
- deprecated previous methods