### PR TITLE
Add interpret generator; add tests for it

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -16,7 +16,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: julia-actions/setup-julia@v2
               with:
-                version: "1.8"
+                version: "1"
             - uses: julia-actions/cache@v2
             - name: Extract Package Name from Project.toml
               id: extract-package-name

--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,14 @@ HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
 HerbGrammar = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 HerbSpecification = "6d54aada-062f-46d8-85cf-a1ceaf058a06"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
+RuntimeGeneratedFunctions = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 
 [compat]
 HerbCore = "1"
 HerbGrammar = "1"
 HerbSpecification = "1"
 MLStyle = "0.4.17"
+RuntimeGeneratedFunctions = "0.5.16"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,19 @@
 name = "HerbInterpret"
 uuid = "5bbddadd-02c5-4713-84b8-97364418cca7"
+version = "1.0.0"
 authors = ["Tilman Hinnerichs <t.r.hinnerichs@tudelft.nl>", "Jaap de Jong <jaapdejong15@gmail.com>", "Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Reuben Gardos Reid <R.J.GardosReid@tudelft.nl>"]
-version = "0.2.1"
 
 [deps]
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
 HerbGrammar = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 HerbSpecification = "6d54aada-062f-46d8-85cf-a1ceaf058a06"
+MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 
 [compat]
-HerbCore = "^0.3.0"
-HerbGrammar = "0.6"
-HerbSpecification = "0.2"
+HerbCore = "1"
+HerbGrammar = "1"
+HerbSpecification = "1"
+MLStyle = "0.4.17"
 julia = "1.10"
 
 [extras]

--- a/src/HerbInterpret.jl
+++ b/src/HerbInterpret.jl
@@ -5,10 +5,14 @@ using HerbGrammar
 using HerbSpecification
 
 include("interpreter.jl")
+include("make_interpret.jl")
 
 export 
     SymbolTable,
     interpret,
 
-    execute_on_input
+    execute_on_input,
+    build_match_cases,
+    make_interpreter, 
+    get_relevant_tags
 end # module HerbInterpret

--- a/src/HerbInterpret.jl
+++ b/src/HerbInterpret.jl
@@ -11,8 +11,11 @@ export
     SymbolTable,
     interpret,
 
-    @make_interpreter,
     execute_on_input,
+
+    @make_interpreter,
+    @make_stateful_interpreter,
     build_match_cases,
+    build_match_cases_stateful
     get_relevant_tags
 end # module HerbInterpret

--- a/src/HerbInterpret.jl
+++ b/src/HerbInterpret.jl
@@ -11,8 +11,8 @@ export
     SymbolTable,
     interpret,
 
+    @make_interpreter,
     execute_on_input,
     build_match_cases,
-    make_interpreter, 
     get_relevant_tags
 end # module HerbInterpret

--- a/src/HerbInterpret.jl
+++ b/src/HerbInterpret.jl
@@ -13,9 +13,8 @@ export
 
     execute_on_input,
 
-    @make_interpreter,
+    make_interpreter,
     @make_stateful_interpreter,
     build_match_cases,
     build_match_cases_stateful
-    get_relevant_tags
 end # module HerbInterpret

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -13,22 +13,6 @@ A tag is treated as an *input terminal* if:
 _is_input_tag(tag, input_set) =
     tag isa Symbol && (occursin("_arg_", String(tag)) || (input_set !== nothing && (tag in input_set)))
 
-# Example: :(Number + 1)  ->  Expr(:call, :+, :Number, 1)   (as *code*)
-_pat_atom(x) =
-    x isa Symbol ? QuoteNode(x) :
-    x isa Expr   ? _pat_expr(x) :
-    x
-
-"""
-    _pat_expr(ex::Expr)
-
-Internal helper that converts an `Expr` value into an MLStyle-friendly pattern AST. E.g. :(Number + 1) cannot be used directly on the left-hand-side of `@match`.
-"""
-function _pat_expr(ex::Expr)
-    return Expr(:call, :Expr, QuoteNode(ex.head), (_pat_atom(a) for a in ex.args)...)
-end
-
-
 """
     get_relevant_tags(grammar::AbstractGrammar) -> Dict{Int,Any}
 
@@ -70,38 +54,46 @@ function get_relevant_tags(grammar::AbstractGrammar)
 end
 
 
+# Resolve symbol `f` in `target_module` at compile time.
+function _qualify(target_module::Module, f)
+    return f isa Symbol ? GlobalRef(target_module, f) : f
+end
+
+
 """
-    build_match_cases(grammar::AbstractGrammar; interp_name=:interpret, input_symbols=nothing) -> Vector{Expr}
+    build_match_cases(grammar; interp_name=:interpret, input_symbols=nothing, target_module=@__MODULE__) -> Vector{Expr}
 
-Generate the case list inserted into `MLStyle.@match`.
+Return a vector of "guarded return" branches of the form:
 
-The generated cases implement a recursive interpreter of a `prog::AbstractRuleNode`:
+    r == k && return <rhs>
+
+These branches are intended to be spliced into a block after
+`r = get_rule(prog); c = get_children(prog)`.
 """
 function build_match_cases(
         grammar::AbstractGrammar;
         interp_name::Symbol = :interpret,
         input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing,
+        target_module::Module = @__MODULE__,
     )
-    tags  = get_relevant_tags(grammar)
-    cases = Expr[]
-
     input_set = input_symbols === nothing ? nothing : Set(input_symbols)
 
-    # Build an evaluation Expr from a rule expression, consuming `c[i]` for each nonterminal occurrence.
+    # Emit code to evaluate a rule RHS, consuming children c[i] for nonterminals.
     function emit_eval(x, next_child::Base.RefValue{Int})
         if x isa Symbol
             if x in grammar.types
                 i = next_child[]
                 next_child[] += 1
-                return :( $interp_name(c[$i], grammar_tags, input) )
+                return :( $interp_name(c[$i], input) )
             elseif _is_input_tag(x, input_set)
                 return :( input[$(QuoteNode(x))] )
             else
-                return x
+                # Treat as a constant/function name in the target module
+                return GlobalRef(target_module, x)
             end
         elseif x isa Expr
             if x.head == :call
-                f = x.args[1]
+                f = _qualify(target_module, x.args[1])
                 args = [emit_eval(a, next_child) for a in x.args[2:end]]
                 return Expr(:call, f, args...)
             elseif x.head == :if
@@ -117,107 +109,165 @@ function build_match_cases(
         end
     end
 
-    for (ind, r) in pairs(grammar.rules)
-        tag = tags[ind]
+    branches = Expr[]
 
-        if r isa Expr && r.head == :call
-            if tag isa Symbol
-                # pure operator rule: match the symbol value (:+, :*, ...)
-                nargs = length(r.args) - 1
-                args = [:( $interp_name(c[$i], grammar_tags, input) ) for i in 1:nargs]
-                rhs = Expr(:call, tag, args...)  # calls + / * / etc.
-                push!(cases, :($(QuoteNode(tag)) => $rhs))  # :+ => +(args...)
+    for (ind, rhs_rule) in pairs(grammar.rules)
+        rhs_code = nothing
 
+        if rhs_rule isa Expr && rhs_rule.head == :call
+            op = rhs_rule.args[1]
+            args = rhs_rule.args[2:end]
+
+            pure =
+                (op isa Symbol) &&
+                all(a -> (a isa Symbol) && (a in grammar.types), args)
+
+            if pure
+                nargs = length(args)
+                child_vals = [:( $interp_name(c[$i], input) ) for i in 1:nargs]
+                rhs_code = Expr(:call, _qualify(target_module, op), child_vals...)
             else
-                # partial: match structurally on the Expr tag (avoid :(...) patterns)
                 nxt = Ref(1)
-                rhs = emit_eval(r, nxt)
-                pat = _pat_expr(tag)  # e.g. Expr(:call, :+, :Number, 1)
-                push!(cases, :($pat => $rhs))
+                rhs_code = emit_eval(rhs_rule, nxt)
             end
-        elseif r isa Expr && r.head == :if
-            push!(cases, :( :IF =>
-                $interp_name(c[1], grammar_tags, input) ?
-                    $interp_name(c[2], grammar_tags, input) :
-                    $interp_name(c[3], grammar_tags, input)
-            ))
 
-        elseif _is_input_tag(tag, input_set)
-            push!(cases, :($(QuoteNode(tag)) => input[$(QuoteNode(tag))] ))
+        elseif rhs_rule isa Expr && rhs_rule.head == :if
+            nxt = Ref(1)
+            rhs_code = emit_eval(rhs_rule, nxt)
 
-        elseif tag isa Symbol && !(tag in grammar.types) && !_is_input_tag(tag, input_set)
-            lhs = :( $interp_name(c[1], grammar_tags, input) )
-            rhs = :( $interp_name(c[2], grammar_tags, input) )
-            op_expr = Expr(:call, tag, lhs, rhs)
-            push!(cases, :( $(QuoteNode(tag)) => $op_expr ))
+        elseif rhs_rule isa Symbol
+            # Symbol terminals: input if configured, else constant symbol resolved in target_module
+            if _is_input_tag(rhs_rule, input_set)
+                rhs_code = :( input[$(QuoteNode(rhs_rule))] )
+            else
+                rhs_code = GlobalRef(target_module, rhs_rule)
+            end
+
+        else
+            # Literal terminals: Int, String, etc.
+            rhs_code = rhs_rule
         end
+
+        push!(branches, :( r == $(ind) && return $rhs_code ))
     end
 
-    # Default branch: read from input if it is an input tag, otherwise return tag.
-    push!(cases, :( _ =>
-        begin
-            tag = grammar_tags[r]
-            return tag
-        end
-    ))
-
-    return cases
+    return branches
 end
+
 
 
 """
-    make_interpreter(grammar::AbstractGrammar; name=:interpret, input_symbols=nothing) -> Expr
+    make_interpreter(grammar; name=:interpret, input_symbols=nothing, target_module=@__MODULE__)
 
-Return an expression defining an interpreter function `name(prog, grammar_tags, input)`.
+Generate an interpreter as a simple cascade on the rule index `r`.
+The generated function signature is:
 
-Typical usage:
+    name(prog::AbstractRuleNode, input::AbstractDict{Symbol,Any})
 
-```julia
-g = @cfgrammar begin
-    Number = |(1:2)
-    Number = x
-    Number = Number + Number
-    Number = Number * Number
-    Number = Number + 1
-    Number = x * 2
-end
-rn = @rulenode 5{4{3,2},7}
+and additionally supports:
 
-tags = get_relevant_tags(g)
-ex = make_interpreter(g; name=:interpret_sui, input_symbols=[:x])
-Core.eval(Main, ex)  # or Core.eval(@__MODULE__, ex) to eval into the current module
-out  = interpret_sui(rn, tags, Dict(:x => 1))
-```
+    name(prog::AbstractRuleNode, inputs::AbstractVector{<:AbstractDict{Symbol,Any}})
 """
 function make_interpreter(
         grammar::AbstractGrammar;
         name::Symbol = :interpret,
         input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing,
+        target_module::Module = @__MODULE__,
     )
-    cases = build_match_cases(grammar; interp_name=name, input_symbols=input_symbols)
+    branches = build_match_cases(grammar;
+        interp_name=name,
+        input_symbols=input_symbols,
+        target_module=target_module,
+    )
 
-    # Build the @match call as syntax first 
-    match_expr = quote
-        MLStyle.@match grammar_tags[r] begin
-            $(cases...)
-        end
-    end
-
-    match_ast = Base.macroexpand(@__MODULE__, match_expr; recursive=true)
+    cascade = Expr(:block,
+        branches...,
+        :( error("No matching rule index: ", r) )
+    )
 
     return quote
-        function $(name)(prog::AbstractRuleNode,
-                         grammar_tags::Dict{Int,Any},
-                         input::Dict{Symbol,Any})
-            r = get_rule(prog)
-            c = get_children(prog)
-            $match_ast
+        using HerbCore
+        function $(name)(prog::HerbCore.AbstractRuleNode,
+                         input::AbstractDict{Symbol,Any})
+            r = HerbCore.get_rule(prog)
+            c = HerbCore.get_children(prog)
+            $cascade
         end
 
-        function $(name)(prog::AbstractRuleNode,
-                         grammar_tags::Dict{Int,Any},
-                         input::AbstractVector{Dict{Symbol,Any}})
-            return $(name).((prog,),(grammar_tags,),input)
+        function $(name)(prog::HerbCore.AbstractRuleNode,
+                         inputs::AbstractVector{<:AbstractDict{Symbol,Any}})
+            return $(name).((prog,), inputs)
         end
     end
+end
+
+
+"""
+    @make_interpreter grammar [name=:interpret] [input_symbols=nothing] [module=<caller>] [target_module=<caller>]
+
+Generate and define an interpreter function for `grammar`.
+
+Here we return code that:
+  1) evaluates `grammar_expr` at runtime,
+  2) builds the interpreter definition expression via `HerbInterpret.make_interpreter`,
+  3) evaluates that definition into the chosen module.
+"""
+macro make_interpreter(grammar_expr, args...)
+    # Defaults
+    name_expr   = QuoteNode(:interpret)
+    input_expr  = :(nothing)
+    module_expr = :(nothing)  # optional target module
+
+    # Parse options (keyword-like)
+    for a in args
+        if a isa Expr && a.head == :(=) && length(a.args) == 2
+            key, val = a.args[1], a.args[2]
+            if key === :name
+                # accept only literal symbols; if user passes a bare identifier, treat it as symbol
+                name_expr = val isa Symbol ? QuoteNode(val) : val
+            elseif key === :input_symbols
+                input_expr = val
+            elseif key === :module || key === :target_module
+                module_expr = val
+            else
+                error("@make_interpreter: unknown option $(key). Use name=..., input_symbols=..., and optionally module=...")
+            end
+        else
+            error("@make_interpreter: expected options like name=... and/or input_symbols=... (and optionally module=...), got: $(a)")
+        end
+    end
+
+    # __module__ is the caller module. This is where we want to evaluate our expressions.
+    # We capture this outside of the quote block below, so the runtime code can refer to it safely.
+    caller_mod = __module__
+
+    # Expand into runtime code (IMPORTANT!)
+    # `esc` tells Julia that references inside the returned syntax should be resolved in the *caller’s scope* (where the macro is used), not in the macro’s defining module.
+    return esc(quote
+        # Why we use locals here:
+        # - locals do not exist macro expansion time, so we force the compiler to run `grammar_expr` only when teh returned code runs.
+        # - locals avoid captuing names int he caller module.
+        local _caller = $(QuoteNode(caller_mod))
+
+        # grammar_expr runs at runtime, so `g` can be local inside a  @testset or function
+        local _g = $(grammar_expr)
+
+        local _name = $(name_expr)
+        _name isa Symbol || error("@make_interpreter: name must be a Symbol, got $(typeof(_name))")
+
+        local _inputs = $(input_expr)
+        (_inputs === nothing || _inputs isa AbstractVector{Symbol}) ||
+            error("@make_interpreter: input_symbols must be nothing or a Vector{Symbol}, got $(typeof(_inputs))")
+
+        # If no module was provided, install into caller module.
+        local _target = $(module_expr) === nothing ? _caller : $(module_expr)
+        _target isa Module || error("@make_interpreter: module/target_module must evaluate to a Module, got $(typeof(_target))")
+
+        local _ex = HerbInterpret.make_interpreter(_g; name=_name, input_symbols=_inputs, target_module=_target)
+        # Evaluate here, so it is hidden from user
+        Core.eval(_target, _ex)
+
+        # do not change this to `return nothing`! This will evaluate in the caller function and short-cut it
+        nothing
+    end)
 end

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -1,3 +1,5 @@
+using MLStyle
+
 """
     _is_input_tag(tag, input_set)
 
@@ -394,7 +396,7 @@ macro make_interpreter(grammar_expr, args...)
             key, val = a.args[1], a.args[2]
             if key === :name
                 # accept only literal symbols; if user passes a bare identifier, treat it as symbol
-                name_expr = val isa Symbol ? QuoteNode(val) : val
+                name_expr = val 
             elseif key === :input_symbols
                 input_expr = val
             elseif key === :module || key === :target_module

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -1,4 +1,5 @@
-using MLStyle
+using RuntimeGeneratedFunctions
+RuntimeGeneratedFunctions.init(@__MODULE__) 
 
 """
     _is_input_tag(tag, input_set)
@@ -12,46 +13,6 @@ A tag is treated as an *input terminal* if:
 _is_input_tag(tag, input_set) =
     tag isa Symbol && (occursin("_arg_", String(tag)) || (input_set !== nothing && (tag in input_set)))
 
-"""
-    get_relevant_tags(grammar::AbstractGrammar) -> Dict{Int,Any}
-
-Compute a "tag" for each grammar rule index on which the generated interpreter matches on .
-
-Tagging rules:
-
-- Literal terminals (e.g. `1`, `2`) keep their literal values as tags.
-- Input terminals like `x` or `_arg_1` remain symbols (e.g. `:x`).
-- For `:call` rules:
-  - "Pure operator" rules whose RHS is only nonterminals (e.g. `Number = Number + Number`) are tagged by the operator symbol (e.g. `:+`, `:*`).
-  - "Composite" rules that contain literals or terminals on the RHS (e.g. `Number = Number + 1`,
-    `Number = x * 2`) are tagged by the full expression `Expr` (e.g. `:(Number + 1)`).
-- `:if` rules are tagged as `:IF`.
-- `:block` rules are tagged as `:OpSeq`.
-"""
-function get_relevant_tags(grammar::AbstractGrammar)
-    tags = Dict{Int,Any}()
-    for (ind, r) in pairs(grammar.rules)
-        tags[ind] = if r isa Expr
-            @match r.head begin
-                :block => :OpSeq
-                :if    => :IF
-                :call  => begin
-                    op = r.args[1]
-                    args = r.args[2:end]
-                    pure =
-                        (op isa Symbol) &&
-                        all(a -> (a isa Symbol) && (a in grammar.types), args)
-                    pure ? op : r  # composites like (Number + 1) keep full Expr as tag
-                end
-                _ => r.head
-            end
-        else
-            r
-        end
-    end
-    return tags
-end
-
 
 """
     _qualify(target_module::Module, f)
@@ -64,7 +25,7 @@ end
 
 
 """
-    build_match_cases(grammar; interp_name=:interpret, input_symbols=nothing, target_module=@__MODULE__)
+    build_match_cases(grammar; target_module=@__MODULE__, input_symbols=nothing)
 
 Return a vector of "guarded return" branches of the form:
 
@@ -76,46 +37,41 @@ These branches are intended to be spliced into a block after
 Returns a vector of branching expressions.
 """
 function build_match_cases(
-        grammar::AbstractGrammar;
-        interp_name::Symbol = :interpret,
-        input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing,
-        target_module::Module = @__MODULE__,
-    )
+    grammar::AbstractGrammar;
+    target_module::Module = @__MODULE__,
+    input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing,
+)
     input_set = input_symbols === nothing ? nothing : Set(input_symbols)
+
+    # recurse on child i as: self(self, c[i], input)
+    recur(i) = :( self(self, c[$i], input) )
 
     # Emit code to evaluate a rule RHS, consuming children c[i] for nonterminals.
     function emit_eval(x, next_child::Base.RefValue{Int})
         if x isa Symbol
             if x in grammar.types
-                # E.g., x is first Number symbol in Number + Number, then pick the first child 
                 i = next_child[]
                 next_child[] += 1
-                return :( $interp_name(c[$i], input) )
+                return recur(i)
             elseif _is_input_tag(x, input_set)
-                # If x is an input return a QuoteNode that refers to the input symbol
                 return :( input[$(QuoteNode(x))] )
             else
-                # Otherwise, check whether the symbol is defined in the original module.
                 return GlobalRef(target_module, x)
             end
         elseif x isa Expr
             if x.head == :call
-                # Regular expression, like :(Number + 1). Run target_module.func on the children.
                 f = _qualify(target_module, x.args[1])
                 args = [emit_eval(a, next_child) for a in x.args[2:end]]
                 return Expr(:call, f, args...)
             elseif x.head == :if
-                # get the expressions for the children and combine in if-then-else statement
                 cond = emit_eval(x.args[1], next_child)
                 tbr  = emit_eval(x.args[2], next_child)
                 fbr  = emit_eval(x.args[3], next_child)
                 return Expr(:if, cond, tbr, fbr)
             else
-                # Otherwise copy the original expression head and recurse on the children.
                 return Expr(x.head, (emit_eval(a, next_child) for a in x.args)...)
             end
         else
-            # x is e.g. a constant
             return x
         end
     end
@@ -126,22 +82,18 @@ function build_match_cases(
         rhs_code = nothing
 
         if rhs_rule isa Expr && rhs_rule.head == :call
-            op = rhs_rule.args[1]
+            op   = rhs_rule.args[1]
             args = rhs_rule.args[2:end]
 
-            # "pure" checks whether rhs only contains a single symbol/operator
-            # Used to check for composite rules, e.g., Number = Number + 1
             pure =
                 (op isa Symbol) &&
                 all(a -> (a isa Symbol) && (a in grammar.types), args)
 
             if pure
-                # rhs only contains single symbol/operator
                 nargs = length(args)
-                child_vals = [:( $interp_name(c[$i], input) ) for i in 1:nargs]
+                child_vals = [recur(i) for i in 1:nargs]
                 rhs_code = Expr(:call, _qualify(target_module, op), child_vals...)
             else
-                # Evaluate rhs, and recurse on children
                 nxt = Ref(1)
                 rhs_code = emit_eval(rhs_rule, nxt)
             end
@@ -152,16 +104,13 @@ function build_match_cases(
 
         elseif rhs_rule isa Symbol
             if rhs_rule in grammar.types
-                # Check whether rhs is a grammar type, e.g., Start = Number 
-                # Proceed to children in that case
-                rhs_code = :( $interp_name(c[1], input) )
+                rhs_code = recur(1)  # Start = Number  etc.
             elseif _is_input_tag(rhs_rule, input_set)
-                # rhs is an input, then use the input dict
                 rhs_code = :( input[$(QuoteNode(rhs_rule))] )
             else
-                # Otherwise use the function defined in the target module
                 rhs_code = GlobalRef(target_module, rhs_rule)
             end
+
         else
             rhs_code = rhs_rule
         end
@@ -173,88 +122,174 @@ function build_match_cases(
 end
 
 
+struct GeneratedInterpreter{F}
+    core::F
+end
+
+# Single input
+function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
+                                   input::AbstractDict{Symbol,Any})
+    return gi.core(gi.core, prog, input)
+end
+
+# Vector of inputs
+function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
+                                   inputs::AbstractVector{<:AbstractDict{Symbol,Any}})
+    return (gi.core).((gi.core,), (prog,), inputs)   # broadcasts (self, prog, input)
+end
+
+function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
+                                   ex::HerbSpecification.IOExample)
+    return gi(prog, ex.in)
+end
+
+function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
+                                   exs::AbstractVector{<:HerbSpecification.IOExample})
+    return [gi(prog, ex) for ex in exs]
+end
+
+
 """
-    build_match_cases_stateful( grammar::AbstractGrammar; interp_name::Symbol = :interpret, target_module::Module = @__MODULE__, state_name::Symbol = :state)
+    make_interpreter(grammar::AbstractGrammar; input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing, target_module::Module = @__MODULE__, cache_module::Module = HerbInterpret)
 
-Generate the branch list for a *state-threading* interpreter.
 
-This function does **not** create the interpreter by itself; it returns a vector of expressions
-(`branches`) that are meant to be spliced into a generated function body after computing.
+Construct a fast, *runtime-generated* interpreter for programs represented as
+`HerbCore.AbstractRuleNode`s.
 
-Each branch has the simple form: `r == k && return <rhs>` where k is the grammar rule index and <rhs> is the generated Julia code for evaluating the
-right-hand-side of that grammar rule.
+The returned value is a callable `GeneratedInterpreter` (a small wrapper around a
+`RuntimeGeneratedFunctions.RuntimeGeneratedFunction`) that can be applied to:
 
-Returns a vector of branching expression for each grammar rule.
+- a single input dictionary:
+  `interp(prog, input::AbstractDict{Symbol,Any})`
+- a vector of input dictionaries:
+  `interp(prog, inputs::AbstractVector{<:AbstractDict{Symbol,Any}})`
+- a single `HerbSpecification.IOExample`:
+  `interp(prog, ex::IOExample)` (uses `ex.in`)
+- a vector of `IOExample`s:
+  `interp(prog, exs::AbstractVector{<:IOExample})`
+
+## Arguments
+
+- `grammar`: The grammar whose rule indices define the operational semantics.
+  The interpreter dispatches by `r = HerbCore.get_rule(prog)`.
+
+## Keyword arguments
+
+- `input_symbols`: Optional list of symbols that should be interpreted as *inputs*.  If provided, terminals matching these symbols (and any symbol following the `_arg_` convention) are read from the `input` dict.
+
+- `target_module`: Module in which operator/function symbols appearing in the grammar are resolved. This is important when the grammar uses domain-specific primitives (e.g. `concat_cvc`, `substr_cvc`) that are defined in a benchmark module rather than in the caller’s module.
+
+- `cache_module`: Module used by `RuntimeGeneratedFunctions.jl` to store its internal cache. 
+"""
+function make_interpreter(grammar::AbstractGrammar;
+    input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing,
+    target_module::Module = @__MODULE__,
+    cache_module::Module = HerbInterpret
+)
+    # ensure the cache exists in the chosen cache module
+    RuntimeGeneratedFunctions.init(cache_module)
+
+    # build if-then-else statements to evaluate the expressions
+    branches = build_match_cases(grammar;
+        target_module = target_module,
+        input_symbols = input_symbols
+    )
+
+    # Add error for non-existent indices
+    cascade = Expr(:block, branches..., :(error("No matching rule index: ", r)))
+
+    # Bit of meta-programming magic:
+    # Constructs an anonymous function with an extra self arg for recursion.
+    ex = :(function (self, prog, input)
+        r = HerbCore.get_rule(prog)
+        c = HerbCore.get_children(prog)
+        $cascade
+    end)
+    Base.remove_linenums!(ex)
+
+    # Call RuntimeGeneratedFunction on this, so we can directly use it
+    core = RuntimeGeneratedFunctions.RuntimeGeneratedFunction(cache_module, target_module, ex)
+    return GeneratedInterpreter(core)
+end
+
+
+"""
+    build_match_cases_stateful_rgf(grammar; target_module=@__MODULE__, state_name=:state, max_steps=1000)
+
+Like `build_match_cases_stateful`, but emits code for a RuntimeGeneratedFunction body:
+- recursion is expressed as `self(self, child, state)`
+- `WHILE` is inlined (bounded by `max_steps`) to avoid needing external helpers
 """
 function build_match_cases_stateful(
         grammar::AbstractGrammar;
-        interp_name::Symbol = :interpret,
         target_module::Module = @__MODULE__,
-        state_name::Symbol = :state
+        state_name::Symbol = :state,
     )
-
     branches = Expr[]
+    max_steps=1000
 
-    # helper: recurse on child i
-    child_call(i) = :($interp_name(c[$i], $(state_name)))
+    # recurse into i-th child with threaded state
+    child_call(i) = :( self(self, c[$i], $(state_name)) )
 
     for (ind, rhs_rule) in pairs(grammar.rules)
         rhs_code = nothing
 
         if rhs_rule isa Expr
-            # Sequencing: (A; B) often becomes :block
             if rhs_rule.head == :block
-                # Convention: block has two statements e.g. for (Operation; Sequence)
-                # children are then [Operation, Sequence]
-                rhs_code = :( $interp_name(c[2], $interp_name(c[1], $(state_name))) )
+                # (A; B) sequencing
+                rhs_code = :( self(self, c[2], self(self, c[1], $(state_name))) )
 
             elseif rhs_rule.head == :call && rhs_rule.args[1] == :(;)
-                # Some grammars encode `;` as a call:
-                rhs_code = :( $interp_name(c[2], $interp_name(c[1], $(state_name))) )
+                # alternative encoding of sequencing
+                rhs_code = :( self(self, c[2], self(self, c[1], $(state_name))) )
 
             elseif rhs_rule.head == :call && rhs_rule.args[1] == :IF
-                # IF special-form: IF(Cond, T, F)
-                rhs_code = :( $interp_name(c[1], $(state_name)) ?
-                                $interp_name(c[2], $(state_name)) :
-                                $interp_name(c[3], $(state_name)) )
+                rhs_code = :( self(self, c[1], $(state_name)) ?
+                              self(self, c[2], $(state_name)) :
+                              self(self, c[3], $(state_name)) )
 
             elseif rhs_rule.head == :call && rhs_rule.args[1] == :WHILE
-                # Either inline loop or call helper in target module.
-                # Here: call helper `command_while(cond, body, state, max_steps)`
-                rhs_code = Expr(:call,
-                                _qualify(target_module, :command_while),
-                                :(c[1]), :(c[2]), :( $(state_name) ))
+                # Inline a bounded while-loop:
+                # WHILE(cond, body)
+                rhs_code = quote
+                    local st  = $(state_name)
+                    local ctr = $(max_steps)
+                    while ctr > 0 && self(self, c[1], st)
+                        st = self(self, c[2], st)
+                        ctr -= 1
+                    end
+                    st
+                end
 
             elseif rhs_rule.head == :call
-                f = rhs_rule.args[1]
+                f    = rhs_rule.args[1]
                 args = rhs_rule.args[2:end]
 
-                # Most stateful primitives appear as 0-arg calls in the grammar:
+                # Most stateful primitives are 0-arg: inc(), moveRight(), etc.
                 if isempty(args)
                     rhs_code = Expr(:call, _qualify(target_module, f), state_name)
                 else
-                    # For calls with nonterminals, just evaluate children in order
-                    # (works for pure combinators; IF/WHILE handled above)
-                    nargs = length(args)
+                    # For calls with nonterminals, interpret children and pass results
+                    nargs      = length(args)
                     child_vals = [child_call(i) for i in 1:nargs]
-                    rhs_code = Expr(:call, _qualify(target_module, f), child_vals...)
+                    rhs_code   = Expr(:call, _qualify(target_module, f), child_vals...)
                 end
             else
-                # Any other Expr: conservatively "recurse first child"
-                rhs_code = :( $interp_name(c[1], $(state_name)) )
+                # fallback: forward to first child
+                rhs_code = :( self(self, c[1], $(state_name)) )
             end
 
         elseif rhs_rule isa Symbol
             if rhs_rule in grammar.types
-                # Alias: Start = Number, Sequence = Operation, etc.
-                rhs_code = :( $interp_name(c[1], $(state_name)) )
+                # Alias: Start = Sequence, etc.
+                rhs_code = :( self(self, c[1], $(state_name)) )
             else
-                # A symbol terminal in a stateful DSL usually means "call it on state" (rare case)
+                # Rare: terminal symbol treated as primitive on state
                 rhs_code = Expr(:call, _qualify(target_module, rhs_rule), state_name)
             end
 
         else
-            # Literal terminals: just return it
+            # literal terminal
             rhs_code = rhs_rule
         end
 
@@ -265,236 +300,65 @@ function build_match_cases_stateful(
 end
 
 
-"""
-    make_interpreter(grammar; name=:interpret, input_symbols=nothing, target_module=@__MODULE__)
+struct GeneratedStatefulInterpreter{F}
+    core::F  # RuntimeGeneratedFunction
+end
 
-Generate an interpreter as a simple cascade on the rule index `r`. 
+# single state
+function (gi::GeneratedStatefulInterpreter)(prog::HerbCore.AbstractRuleNode, state)
+    return gi.core(gi.core, prog, state)
+end
 
-This function returns a quoted expression (`Expr`) that, when evaluated (e.g. with `Core.eval`), defines an interpreter function `name` that executes a program represented by an `HerbCore.AbstractRuleNode` on a given set of inputs.
+# vector of states
+function (gi::GeneratedStatefulInterpreter)(prog::HerbCore.AbstractRuleNode, states::AbstractVector)
+    core = gi.core
+    return core.((core,), (prog,), states)
+end
 
-Allows to customize input symbols, the target module, and the name of the function.
-"""
-function make_interpreter(
-        grammar::AbstractGrammar;
-        name::Symbol = :interpret,
-        input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing,
-        target_module::Module = @__MODULE__,
-    )
-    branches = build_match_cases(grammar;
-        interp_name=name,
-        input_symbols=input_symbols,
-        target_module=target_module,
-    )
+# IOExample (state in :_arg_1)
+function (gi::GeneratedStatefulInterpreter)(prog::HerbCore.AbstractRuleNode, ex::HerbSpecification.IOExample)
+    return gi(prog, ex.in[:_arg_1])
+end
 
-    cascade = Expr(:block,
-        branches...,
-        :( error("No matching rule index: ", r) )
-    )
-
-    return quote
-        using HerbCore
-        using HerbSpecification
-        # Single input dictionary
-        function $(name)(prog::HerbCore.AbstractRuleNode,
-                        input::AbstractDict{Symbol,Any})
-            r = HerbCore.get_rule(prog)
-            c = HerbCore.get_children(prog)
-            $cascade
-        end
-
-        # Multiple input dictionaries
-        function $(name)(prog::HerbCore.AbstractRuleNode,
-                        inputs::AbstractVector{<:AbstractDict{Symbol,Any}})
-            return $(name).((prog,), inputs)
-        end
-
-        # Single IOExample: use example.in as the input dictionary
-        function $(name)(prog::HerbCore.AbstractRuleNode,
-                        ex::HerbSpecification.IOExample)
-            return $(name)(prog, ex.in)
-        end
-
-        # Multiple IOExamples: evaluate on each example.in
-        function $(name)(prog::HerbCore.AbstractRuleNode,
-                        exs::AbstractVector{<:HerbSpecification.IOExample})
-            return [$(name)(prog, ex.in) for ex in exs]
-        end
-    end
+# vector of IOExamples
+function (gi::GeneratedStatefulInterpreter)(prog::HerbCore.AbstractRuleNode, exs::AbstractVector{<:HerbSpecification.IOExample})
+    return [gi(prog, ex) for ex in exs]
 end
 
 
 """
-    make_stateful_interpreter(
-        grammar::AbstractGrammar;
-        name::Symbol = :interpret,
-        target_module::Module = @__MODULE__,
-    ) -> Expr
+    make_stateful_interpreter_rgf(grammar; target_module=@__MODULE__, cache_module=HerbInterpret, max_steps=1000)
 
-Generate an interpreter *definition* for a **state-threading DSL** as an expression.
+Build a RuntimeGeneratedFunctions-backed state-threading interpreter.
 
-This function returns a quoted expression (`Expr`) that, when evaluated (e.g. with `Core.eval`), defines an interpreter function `name` that executes a program represented by an `HerbCore.AbstractRuleNode` on an explicit *state* value.
+- `target_module` controls where primitives (inc, moveRight, etc.) are resolved.
+- `cache_module` controls where RGF stores its cache. **This module must have**
+  `RuntimeGeneratedFunctions.init(@__MODULE__)` executed at module top level.
+- `max_steps` bounds generated WHILE loops.
 """
 function make_stateful_interpreter(
         grammar::AbstractGrammar;
-        name::Symbol = :interpret,
-        target_module::Module = @__MODULE__
+        target_module::Module = @__MODULE__,
+        cache_module::Module  = HerbInterpret,
     )
+    # IMPORTANT: cache_module must be initialized at module top-level.
+    RuntimeGeneratedFunctions.init(cache_module)
+
     branches = build_match_cases_stateful(grammar;
-        interp_name=name,
-        target_module=target_module,
-        state_name=:state
+        target_module = target_module,
+        state_name    = :state
     )
 
-    cascade = Expr(:block,
-        branches...,
-        :( error("No matching rule index: ", r) )
-    )
+    cascade = Expr(:block, branches..., :(error("No matching rule index: ", r)))
 
-    return quote
-        using HerbCore
-        using HerbSpecification
-        function $(name)(prog::HerbCore.AbstractRuleNode, state)
-            r = HerbCore.get_rule(prog)
-            c = HerbCore.get_children(prog)
-            $cascade
-        end
-
-        function $(name)(prog::HerbCore.AbstractRuleNode, states::AbstractVector)
-            return $(name).((prog,), states)
-        end
-
-        function $(name)(prog::HerbCore.AbstractRuleNode, ex::HerbSpecification.IOExample)
-            return $(name)(prog, ex.in[:_arg_1])
-        end
-
-        function $(name)(prog::HerbCore.AbstractRuleNode, exs::AbstractVector{<:HerbSpecification.IOExample})
-            return [$(name)(prog, ex) for ex in exs]
-        end
-    end
-end
-
-
-"""
-    @make_interpreter grammar [name=:interpret] [input_symbols=nothing] [module=<caller>] [target_module=<caller>]
-
-Generate and define an interpreter function for `grammar`.
-
-Here we return code that:
-  1) evaluates `grammar_expr` at runtime,
-  2) builds the interpreter definition expression via `HerbInterpret.make_interpreter`,
-  3) evaluates that definition into the chosen module.
-"""
-macro make_interpreter(grammar_expr, args...)
-    # Defaults
-    name_expr   = QuoteNode(:interpret)
-    input_expr  = :(nothing)
-    module_expr = :(nothing)  # optional target module
-
-    # Parse options (keyword-like)
-    for a in args
-        if a isa Expr && a.head == :(=) && length(a.args) == 2
-            key, val = a.args[1], a.args[2]
-            if key === :name
-                # accept only literal symbols; if user passes a bare identifier, treat it as symbol
-                name_expr = val 
-            elseif key === :input_symbols
-                input_expr = val
-            elseif key === :module || key === :target_module
-                module_expr = val
-            else
-                error("@make_interpreter: unknown option $(key). Use name=..., input_symbols=..., and optionally module=...")
-            end
-        else
-            error("@make_interpreter: expected options like name=... and/or input_symbols=... (and optionally module=...), got: $(a)")
-        end
-    end
-
-    # __module__ is the caller module. This is where we want to evaluate our expressions.
-    # We capture this outside of the quote block below, so the runtime code can refer to it safely.
-    caller_mod = __module__
-
-    # Expand into runtime code (IMPORTANT!)
-    # `esc` tells Julia that references inside the returned syntax should be resolved in the *caller’s scope* (where the macro is used), not in the macro’s defining module.
-    return esc(quote
-        # Why we use locals here:
-        # - locals do not exist macro expansion time, so we force the compiler to run `grammar_expr` only when teh returned code runs.
-        # - locals avoid captuing names int he caller module.
-        local _caller = $(QuoteNode(caller_mod))
-
-        # grammar_expr runs at runtime, so `g` can be local inside a  @testset or function
-        local _g = $(grammar_expr)
-
-        local _name = $(name_expr)
-        _name isa Symbol || error("@make_interpreter: name must be a Symbol, got $(typeof(_name))")
-
-        local _inputs = $(input_expr)
-        (_inputs === nothing || _inputs isa AbstractVector{Symbol}) ||
-            error("@make_interpreter: input_symbols must be nothing or a Vector{Symbol}, got $(typeof(_inputs))")
-
-        # If no module was provided, install into caller module.
-        local _target = $(module_expr) === nothing ? _caller : $(module_expr)
-        _target isa Module || error("@make_interpreter: module/target_module must evaluate to a Module, got $(typeof(_target))")
-
-        local _ex = HerbInterpret.make_interpreter(_g; name=_name, input_symbols=_inputs, target_module=_target)
-        # Evaluate here, so it is hidden from user
-        Core.eval(_target, _ex)
-
-        # do not change this to `return nothing`! This will evaluate in the caller function and short-cut it
-        nothing
+    # RGF body is an anonymous function. We add `self` for recursion.
+    ex = :(function (self, prog, state)
+        r = HerbCore.get_rule(prog)
+        c = HerbCore.get_children(prog)
+        $cascade
     end)
+    Base.remove_linenums!(ex)
+
+    core = RuntimeGeneratedFunctions.RuntimeGeneratedFunction(cache_module, target_module, ex)
+    return GeneratedStatefulInterpreter(core)
 end
-
-"""
-    @make_stateful_interpreter grammar [name=:interpret] [module=<caller>] [target_module=<caller>]
-
-Generate and define a *state-threading* interpreter function for `grammar`.
-
-The generated function(s) have signatures:
-
-    name(prog::HerbCore.AbstractRuleNode, state)
-    name(prog::HerbCore.AbstractRuleNode, states::AbstractVector)
-    name(prog::HerbCore.AbstractRuleNode, ex::HerbSpecification.IOExample)
-    name(prog::HerbCore.AbstractRuleNode, exs::AbstractVector{<:HerbSpecification.IOExample} 
-
-The macro expands to *runtime code* builds the definition expression via `HerbInterpret.make_stateful_interpreter`, and `Core.eval`s it into the chosen module.
-"""
-macro make_stateful_interpreter(grammar_expr, args...)
-    # Defaults
-    name_expr   = QuoteNode(:interpret)
-    module_expr = :(nothing)  # optional target module
-
-    # Parse options (keyword-like)
-    for a in args
-        if a isa Expr && a.head == :(=) && length(a.args) == 2
-            key, val = a.args[1], a.args[2]
-            if key === :name
-                name_expr = val isa Symbol ? QuoteNode(val) : val
-            elseif key === :module || key === :target_module
-                module_expr = val
-            else
-                error("@make_stateful_interpreter: unknown option $(key). Use name=... and optionally target_module=...")
-            end
-        else
-            error("@make_stateful_interpreter: expected options like name=... (and optionally target_module=...), got: $(a)")
-        end
-    end
-
-    caller_mod = __module__
-
-    return esc(quote
-        local _caller = $(QuoteNode(caller_mod))
-        local _g      = $(grammar_expr)
-
-        local _name = $(name_expr)
-        _name isa Symbol || error("@make_stateful_interpreter: name must be a Symbol, got $(typeof(_name))")
-
-        local _target = $(module_expr) === nothing ? _caller : $(module_expr)
-        _target isa Module || error("@make_stateful_interpreter: target_module must evaluate to a Module, got $(typeof(_target))")
-
-        local _ex = HerbInterpret.make_stateful_interpreter(_g; name=_name, target_module=_target)
-        Core.eval(_target, _ex)
-
-        nothing
-    end)
-end
-

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -88,7 +88,6 @@ function build_match_cases(
             elseif _is_input_tag(x, input_set)
                 return :( input[$(QuoteNode(x))] )
             else
-                # Treat as a constant/function name in the target module
                 return GlobalRef(target_module, x)
             end
         elseif x isa Expr
@@ -136,15 +135,16 @@ function build_match_cases(
             rhs_code = emit_eval(rhs_rule, nxt)
 
         elseif rhs_rule isa Symbol
-            # Symbol terminals: input if configured, else constant symbol resolved in target_module
-            if _is_input_tag(rhs_rule, input_set)
+            if rhs_rule in grammar.types
+                # NEW: pass-through alias rule like Start = Number
+                rhs_code = :( $interp_name(c[1], input) )
+            elseif _is_input_tag(rhs_rule, input_set)
                 rhs_code = :( input[$(QuoteNode(rhs_rule))] )
             else
                 rhs_code = GlobalRef(target_module, rhs_rule)
             end
 
         else
-            # Literal terminals: Int, String, etc.
             rhs_code = rhs_rule
         end
 
@@ -179,6 +179,8 @@ function make_interpreter(
         input_symbols=input_symbols,
         target_module=target_module,
     )
+
+    @show branches
 
     cascade = Expr(:block,
         branches...,

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -1,0 +1,223 @@
+using MLStyle
+
+# Treat as input if it follows _arg_ convention OR user explicitly listed it
+"""
+    _is_input_tag(tag, input_set)
+
+Checks whether a tag is an input. 
+A tag is treated as an *input terminal* if:
+
+1. it is a `Symbol` that contains the substring `"_arg_"` (the default convention), OR
+2. `input_set` is provided and `tag ∈ input_set`.
+"""
+_is_input_tag(tag, input_set) =
+    tag isa Symbol && (occursin("_arg_", String(tag)) || (input_set !== nothing && (tag in input_set)))
+
+# Example: :(Number + 1)  ->  Expr(:call, :+, :Number, 1)   (as *code*)
+_pat_atom(x) =
+    x isa Symbol ? QuoteNode(x) :
+    x isa Expr   ? _pat_expr(x) :
+    x
+
+"""
+    _pat_expr(ex::Expr)
+
+Internal helper that converts an `Expr` value into an MLStyle-friendly pattern AST. E.g. :(Number + 1) cannot be used directly on the left-hand-side of `@match`.
+"""
+function _pat_expr(ex::Expr)
+    return Expr(:call, :Expr, QuoteNode(ex.head), (_pat_atom(a) for a in ex.args)...)
+end
+
+
+"""
+    get_relevant_tags(grammar::AbstractGrammar) -> Dict{Int,Any}
+
+Compute a "tag" for each grammar rule index on which the generated interpreter matches on .
+
+Tagging rules:
+
+- Literal terminals (e.g. `1`, `2`) keep their literal values as tags.
+- Input terminals like `x` or `_arg_1` remain symbols (e.g. `:x`).
+- For `:call` rules:
+  - "Pure operator" rules whose RHS is only nonterminals (e.g. `Number = Number + Number`) are tagged by the operator symbol (e.g. `:+`, `:*`).
+  - "Composite" rules that contain literals or terminals on the RHS (e.g. `Number = Number + 1`,
+    `Number = x * 2`) are tagged by the full expression `Expr` (e.g. `:(Number + 1)`).
+- `:if` rules are tagged as `:IF`.
+- `:block` rules are tagged as `:OpSeq`.
+"""
+function get_relevant_tags(grammar::AbstractGrammar)
+    tags = Dict{Int,Any}()
+    for (ind, r) in pairs(grammar.rules)
+        tags[ind] = if r isa Expr
+            @match r.head begin
+                :block => :OpSeq
+                :if    => :IF
+                :call  => begin
+                    op = r.args[1]
+                    args = r.args[2:end]
+                    pure =
+                        (op isa Symbol) &&
+                        all(a -> (a isa Symbol) && (a in grammar.types), args)
+                    pure ? op : r  # composites like (Number + 1) keep full Expr as tag
+                end
+                _ => r.head
+            end
+        else
+            r
+        end
+    end
+    return tags
+end
+
+
+"""
+    build_match_cases(grammar::AbstractGrammar; interp_name=:interpret, input_symbols=nothing) -> Vector{Expr}
+
+Generate the case list inserted into `MLStyle.@match`.
+
+The generated cases implement a recursive interpreter of a `prog::AbstractRuleNode`:
+"""
+function build_match_cases(
+        grammar::AbstractGrammar;
+        interp_name::Symbol = :interpret,
+        input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing,
+    )
+    tags  = get_relevant_tags(grammar)
+    cases = Expr[]
+
+    input_set = input_symbols === nothing ? nothing : Set(input_symbols)
+
+    # Build an evaluation Expr from a rule expression, consuming `c[i]` for each nonterminal occurrence.
+    function emit_eval(x, next_child::Base.RefValue{Int})
+        if x isa Symbol
+            if x in grammar.types
+                i = next_child[]
+                next_child[] += 1
+                return :( $interp_name(c[$i], grammar_tags, input) )
+            elseif _is_input_tag(x, input_set)
+                return :( input[$(QuoteNode(x))] )
+            else
+                return x
+            end
+        elseif x isa Expr
+            if x.head == :call
+                f = x.args[1]
+                args = [emit_eval(a, next_child) for a in x.args[2:end]]
+                return Expr(:call, f, args...)
+            elseif x.head == :if
+                cond = emit_eval(x.args[1], next_child)
+                tbr  = emit_eval(x.args[2], next_child)
+                fbr  = emit_eval(x.args[3], next_child)
+                return Expr(:if, cond, tbr, fbr)
+            else
+                return Expr(x.head, (emit_eval(a, next_child) for a in x.args)...)
+            end
+        else
+            return x
+        end
+    end
+
+    for (ind, r) in pairs(grammar.rules)
+        tag = tags[ind]
+
+        if r isa Expr && r.head == :call
+            if tag isa Symbol
+                # pure operator rule: match the symbol value (:+, :*, ...)
+                nargs = length(r.args) - 1
+                args = [:( $interp_name(c[$i], grammar_tags, input) ) for i in 1:nargs]
+                rhs = Expr(:call, tag, args...)  # calls + / * / etc.
+                push!(cases, :($(QuoteNode(tag)) => $rhs))  # :+ => +(args...)
+
+            else
+                # partial: match structurally on the Expr tag (avoid :(...) patterns)
+                nxt = Ref(1)
+                rhs = emit_eval(r, nxt)
+                pat = _pat_expr(tag)  # e.g. Expr(:call, :+, :Number, 1)
+                push!(cases, :($pat => $rhs))
+            end
+        elseif r isa Expr && r.head == :if
+            push!(cases, :( :IF =>
+                $interp_name(c[1], grammar_tags, input) ?
+                    $interp_name(c[2], grammar_tags, input) :
+                    $interp_name(c[3], grammar_tags, input)
+            ))
+
+        elseif _is_input_tag(tag, input_set)
+            push!(cases, :($(QuoteNode(tag)) => input[$(QuoteNode(tag))] ))
+
+        elseif tag isa Symbol && !(tag in grammar.types) && !_is_input_tag(tag, input_set)
+            lhs = :( $interp_name(c[1], grammar_tags, input) )
+            rhs = :( $interp_name(c[2], grammar_tags, input) )
+            op_expr = Expr(:call, tag, lhs, rhs)
+            push!(cases, :( $(QuoteNode(tag)) => $op_expr ))
+        end
+    end
+
+    # Default branch: read from input if it is an input tag, otherwise return tag.
+    push!(cases, :( _ =>
+        begin
+            tag = grammar_tags[r]
+            return tag
+        end
+    ))
+
+    return cases
+end
+
+
+"""
+    make_interpreter(grammar::AbstractGrammar; name=:interpret, input_symbols=nothing) -> Expr
+
+Return an expression defining an interpreter function `name(prog, grammar_tags, input)`.
+
+Typical usage:
+
+```julia
+g = @cfgrammar begin
+    Number = |(1:2)
+    Number = x
+    Number = Number + Number
+    Number = Number * Number
+    Number = Number + 1
+    Number = x * 2
+end
+rn = @rulenode 5{4{3,2},7}
+
+tags = get_relevant_tags(g)
+ex = make_interpreter(g; name=:interpret_sui, input_symbols=[:x])
+Core.eval(Main, ex)  # or Core.eval(@__MODULE__, ex) to eval into the current module
+out  = interpret_sui(rn, tags, Dict(:x => 1))
+```
+"""
+function make_interpreter(
+        grammar::AbstractGrammar;
+        name::Symbol = :interpret,
+        input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing,
+    )
+    cases = build_match_cases(grammar; interp_name=name, input_symbols=input_symbols)
+
+    # Build the @match call as syntax first 
+    match_expr = quote
+        MLStyle.@match grammar_tags[r] begin
+            $(cases...)
+        end
+    end
+
+    match_ast = Base.macroexpand(@__MODULE__, match_expr; recursive=true)
+
+    return quote
+        function $(name)(prog::AbstractRuleNode,
+                         grammar_tags::Dict{Int,Any},
+                         input::Dict{Symbol,Any})
+            r = get_rule(prog)
+            c = get_children(prog)
+            $match_ast
+        end
+
+        function $(name)(prog::AbstractRuleNode,
+                         grammar_tags::Dict{Int,Any},
+                         input::AbstractVector{Dict{Symbol,Any}})
+            return $(name).((prog,),(grammar_tags,),input)
+        end
+    end
+end

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -187,16 +187,31 @@ function make_interpreter(
 
     return quote
         using HerbCore
+        using HerbSpecification
+        # Single input dictionary
         function $(name)(prog::HerbCore.AbstractRuleNode,
-                         input::AbstractDict{Symbol,Any})
+                        input::AbstractDict{Symbol,Any})
             r = HerbCore.get_rule(prog)
             c = HerbCore.get_children(prog)
             $cascade
         end
 
+        # Multiple input dictionaries
         function $(name)(prog::HerbCore.AbstractRuleNode,
-                         inputs::AbstractVector{<:AbstractDict{Symbol,Any}})
+                        inputs::AbstractVector{<:AbstractDict{Symbol,Any}})
             return $(name).((prog,), inputs)
+        end
+
+        # Single IOExample: use example.in as the input dictionary
+        function $(name)(prog::HerbCore.AbstractRuleNode,
+                        ex::HerbSpecification.IOExample)
+            return $(name)(prog, ex.in)
+        end
+
+        # Multiple IOExamples: evaluate on each example.in
+        function $(name)(prog::HerbCore.AbstractRuleNode,
+                        exs::AbstractVector{<:HerbSpecification.IOExample})
+            return [$(name)(prog, ex.in) for ex in exs]
         end
     end
 end

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -1,6 +1,3 @@
-using MLStyle
-
-# Treat as input if it follows _arg_ convention OR user explicitly listed it
 """
     _is_input_tag(tag, input_set)
 
@@ -54,14 +51,18 @@ function get_relevant_tags(grammar::AbstractGrammar)
 end
 
 
-# Resolve symbol `f` in `target_module` at compile time.
+"""
+    _qualify(target_module::Module, f)
+
+Resolve symbol `f` in `target_module` at compile time.
+"""
 function _qualify(target_module::Module, f)
     return f isa Symbol ? GlobalRef(target_module, f) : f
 end
 
 
 """
-    build_match_cases(grammar; interp_name=:interpret, input_symbols=nothing, target_module=@__MODULE__) -> Vector{Expr}
+    build_match_cases(grammar; interp_name=:interpret, input_symbols=nothing, target_module=@__MODULE__)
 
 Return a vector of "guarded return" branches of the form:
 
@@ -69,6 +70,8 @@ Return a vector of "guarded return" branches of the form:
 
 These branches are intended to be spliced into a block after
 `r = get_rule(prog); c = get_children(prog)`.
+
+Returns a vector of branching expressions.
 """
 function build_match_cases(
         grammar::AbstractGrammar;
@@ -82,28 +85,35 @@ function build_match_cases(
     function emit_eval(x, next_child::Base.RefValue{Int})
         if x isa Symbol
             if x in grammar.types
+                # E.g., x is first Number symbol in Number + Number, then pick the first child 
                 i = next_child[]
                 next_child[] += 1
                 return :( $interp_name(c[$i], input) )
             elseif _is_input_tag(x, input_set)
+                # If x is an input return a QuoteNode that refers to the input symbol
                 return :( input[$(QuoteNode(x))] )
             else
+                # Otherwise, check whether the symbol is defined in the original module.
                 return GlobalRef(target_module, x)
             end
         elseif x isa Expr
             if x.head == :call
+                # Regular expression, like :(Number + 1). Run target_module.func on the children.
                 f = _qualify(target_module, x.args[1])
                 args = [emit_eval(a, next_child) for a in x.args[2:end]]
                 return Expr(:call, f, args...)
             elseif x.head == :if
+                # get the expressions for the children and combine in if-then-else statement
                 cond = emit_eval(x.args[1], next_child)
                 tbr  = emit_eval(x.args[2], next_child)
                 fbr  = emit_eval(x.args[3], next_child)
                 return Expr(:if, cond, tbr, fbr)
             else
+                # Otherwise copy the original expression head and recurse on the children.
                 return Expr(x.head, (emit_eval(a, next_child) for a in x.args)...)
             end
         else
+            # x is e.g. a constant
             return x
         end
     end
@@ -117,15 +127,19 @@ function build_match_cases(
             op = rhs_rule.args[1]
             args = rhs_rule.args[2:end]
 
+            # "pure" checks whether rhs only contains a single symbol/operator
+            # Used to check for composite rules, e.g., Number = Number + 1
             pure =
                 (op isa Symbol) &&
                 all(a -> (a isa Symbol) && (a in grammar.types), args)
 
             if pure
+                # rhs only contains single symbol/operator
                 nargs = length(args)
                 child_vals = [:( $interp_name(c[$i], input) ) for i in 1:nargs]
                 rhs_code = Expr(:call, _qualify(target_module, op), child_vals...)
             else
+                # Evaluate rhs, and recurse on children
                 nxt = Ref(1)
                 rhs_code = emit_eval(rhs_rule, nxt)
             end
@@ -136,14 +150,16 @@ function build_match_cases(
 
         elseif rhs_rule isa Symbol
             if rhs_rule in grammar.types
-                # NEW: pass-through alias rule like Start = Number
+                # Check whether rhs is a grammar type, e.g., Start = Number 
+                # Proceed to children in that case
                 rhs_code = :( $interp_name(c[1], input) )
             elseif _is_input_tag(rhs_rule, input_set)
+                # rhs is an input, then use the input dict
                 rhs_code = :( input[$(QuoteNode(rhs_rule))] )
             else
+                # Otherwise use the function defined in the target module
                 rhs_code = GlobalRef(target_module, rhs_rule)
             end
-
         else
             rhs_code = rhs_rule
         end
@@ -155,18 +171,106 @@ function build_match_cases(
 end
 
 
+"""
+    build_match_cases_stateful( grammar::AbstractGrammar; interp_name::Symbol = :interpret, target_module::Module = @__MODULE__, state_name::Symbol = :state)
+
+Generate the branch list for a *state-threading* interpreter.
+
+This function does **not** create the interpreter by itself; it returns a vector of expressions
+(`branches`) that are meant to be spliced into a generated function body after computing.
+
+Each branch has the simple form: `r == k && return <rhs>` where k is the grammar rule index and <rhs> is the generated Julia code for evaluating the
+right-hand-side of that grammar rule.
+
+Returns a vector of branching expression for each grammar rule.
+"""
+function build_match_cases_stateful(
+        grammar::AbstractGrammar;
+        interp_name::Symbol = :interpret,
+        target_module::Module = @__MODULE__,
+        state_name::Symbol = :state
+    )
+
+    branches = Expr[]
+
+    # helper: recurse on child i
+    child_call(i) = :($interp_name(c[$i], $(state_name)))
+
+    for (ind, rhs_rule) in pairs(grammar.rules)
+        rhs_code = nothing
+
+        if rhs_rule isa Expr
+            # Sequencing: (A; B) often becomes :block
+            if rhs_rule.head == :block
+                # Convention: block has two statements e.g. for (Operation; Sequence)
+                # children are then [Operation, Sequence]
+                rhs_code = :( $interp_name(c[2], $interp_name(c[1], $(state_name))) )
+
+            elseif rhs_rule.head == :call && rhs_rule.args[1] == :(;)
+                # Some grammars encode `;` as a call:
+                rhs_code = :( $interp_name(c[2], $interp_name(c[1], $(state_name))) )
+
+            elseif rhs_rule.head == :call && rhs_rule.args[1] == :IF
+                # IF special-form: IF(Cond, T, F)
+                rhs_code = :( $interp_name(c[1], $(state_name)) ?
+                                $interp_name(c[2], $(state_name)) :
+                                $interp_name(c[3], $(state_name)) )
+
+            elseif rhs_rule.head == :call && rhs_rule.args[1] == :WHILE
+                # Either inline loop or call helper in target module.
+                # Here: call helper `command_while(cond, body, state, max_steps)`
+                rhs_code = Expr(:call,
+                                _qualify(target_module, :command_while),
+                                :(c[1]), :(c[2]), :( $(state_name) ))
+
+            elseif rhs_rule.head == :call
+                f = rhs_rule.args[1]
+                args = rhs_rule.args[2:end]
+
+                # Most stateful primitives appear as 0-arg calls in the grammar:
+                if isempty(args)
+                    rhs_code = Expr(:call, _qualify(target_module, f), state_name)
+                else
+                    # For calls with nonterminals, just evaluate children in order
+                    # (works for pure combinators; IF/WHILE handled above)
+                    nargs = length(args)
+                    child_vals = [child_call(i) for i in 1:nargs]
+                    rhs_code = Expr(:call, _qualify(target_module, f), child_vals...)
+                end
+            else
+                # Any other Expr: conservatively "recurse first child"
+                rhs_code = :( $interp_name(c[1], $(state_name)) )
+            end
+
+        elseif rhs_rule isa Symbol
+            if rhs_rule in grammar.types
+                # Alias: Start = Number, Sequence = Operation, etc.
+                rhs_code = :( $interp_name(c[1], $(state_name)) )
+            else
+                # A symbol terminal in a stateful DSL usually means "call it on state" (rare case)
+                rhs_code = Expr(:call, _qualify(target_module, rhs_rule), state_name)
+            end
+
+        else
+            # Literal terminals: just return it
+            rhs_code = rhs_rule
+        end
+
+        push!(branches, :( r == $(ind) && return $rhs_code ))
+    end
+
+    return branches
+end
+
 
 """
     make_interpreter(grammar; name=:interpret, input_symbols=nothing, target_module=@__MODULE__)
 
-Generate an interpreter as a simple cascade on the rule index `r`.
-The generated function signature is:
+Generate an interpreter as a simple cascade on the rule index `r`. 
 
-    name(prog::AbstractRuleNode, input::AbstractDict{Symbol,Any})
+This function returns a quoted expression (`Expr`) that, when evaluated (e.g. with `Core.eval`), defines an interpreter function `name` that executes a program represented by an `HerbCore.AbstractRuleNode` on a given set of inputs.
 
-and additionally supports:
-
-    name(prog::AbstractRuleNode, inputs::AbstractVector{<:AbstractDict{Symbol,Any}})
+Allows to customize input symbols, the target module, and the name of the function.
 """
 function make_interpreter(
         grammar::AbstractGrammar;
@@ -179,8 +283,6 @@ function make_interpreter(
         input_symbols=input_symbols,
         target_module=target_module,
     )
-
-    @show branches
 
     cascade = Expr(:block,
         branches...,
@@ -214,6 +316,57 @@ function make_interpreter(
         function $(name)(prog::HerbCore.AbstractRuleNode,
                         exs::AbstractVector{<:HerbSpecification.IOExample})
             return [$(name)(prog, ex.in) for ex in exs]
+        end
+    end
+end
+
+
+"""
+    make_stateful_interpreter(
+        grammar::AbstractGrammar;
+        name::Symbol = :interpret,
+        target_module::Module = @__MODULE__,
+    ) -> Expr
+
+Generate an interpreter *definition* for a **state-threading DSL** as an expression.
+
+This function returns a quoted expression (`Expr`) that, when evaluated (e.g. with `Core.eval`), defines an interpreter function `name` that executes a program represented by an `HerbCore.AbstractRuleNode` on an explicit *state* value.
+"""
+function make_stateful_interpreter(
+        grammar::AbstractGrammar;
+        name::Symbol = :interpret,
+        target_module::Module = @__MODULE__
+    )
+    branches = build_match_cases_stateful(grammar;
+        interp_name=name,
+        target_module=target_module,
+        state_name=:state
+    )
+
+    cascade = Expr(:block,
+        branches...,
+        :( error("No matching rule index: ", r) )
+    )
+
+    return quote
+        using HerbCore
+        using HerbSpecification
+        function $(name)(prog::HerbCore.AbstractRuleNode, state)
+            r = HerbCore.get_rule(prog)
+            c = HerbCore.get_children(prog)
+            $cascade
+        end
+
+        function $(name)(prog::HerbCore.AbstractRuleNode, states::AbstractVector)
+            return $(name).((prog,), states)
+        end
+
+        function $(name)(prog::HerbCore.AbstractRuleNode, ex::HerbSpecification.IOExample)
+            return $(name)(prog, ex.in[:_arg_1])
+        end
+
+        function $(name)(prog::HerbCore.AbstractRuleNode, exs::AbstractVector{<:HerbSpecification.IOExample})
+            return [$(name)(prog, ex) for ex in exs]
         end
     end
 end
@@ -288,3 +441,58 @@ macro make_interpreter(grammar_expr, args...)
         nothing
     end)
 end
+
+"""
+    @make_stateful_interpreter grammar [name=:interpret] [module=<caller>] [target_module=<caller>]
+
+Generate and define a *state-threading* interpreter function for `grammar`.
+
+The generated function(s) have signatures:
+
+    name(prog::HerbCore.AbstractRuleNode, state)
+    name(prog::HerbCore.AbstractRuleNode, states::AbstractVector)
+    name(prog::HerbCore.AbstractRuleNode, ex::HerbSpecification.IOExample)
+    name(prog::HerbCore.AbstractRuleNode, exs::AbstractVector{<:HerbSpecification.IOExample} 
+
+The macro expands to *runtime code* builds the definition expression via `HerbInterpret.make_stateful_interpreter`, and `Core.eval`s it into the chosen module.
+"""
+macro make_stateful_interpreter(grammar_expr, args...)
+    # Defaults
+    name_expr   = QuoteNode(:interpret)
+    module_expr = :(nothing)  # optional target module
+
+    # Parse options (keyword-like)
+    for a in args
+        if a isa Expr && a.head == :(=) && length(a.args) == 2
+            key, val = a.args[1], a.args[2]
+            if key === :name
+                name_expr = val isa Symbol ? QuoteNode(val) : val
+            elseif key === :module || key === :target_module
+                module_expr = val
+            else
+                error("@make_stateful_interpreter: unknown option $(key). Use name=... and optionally target_module=...")
+            end
+        else
+            error("@make_stateful_interpreter: expected options like name=... (and optionally target_module=...), got: $(a)")
+        end
+    end
+
+    caller_mod = __module__
+
+    return esc(quote
+        local _caller = $(QuoteNode(caller_mod))
+        local _g      = $(grammar_expr)
+
+        local _name = $(name_expr)
+        _name isa Symbol || error("@make_stateful_interpreter: name must be a Symbol, got $(typeof(_name))")
+
+        local _target = $(module_expr) === nothing ? _caller : $(module_expr)
+        _target isa Module || error("@make_stateful_interpreter: target_module must evaluate to a Module, got $(typeof(_target))")
+
+        local _ex = HerbInterpret.make_stateful_interpreter(_g; name=_name, target_module=_target)
+        Core.eval(_target, _ex)
+
+        nothing
+    end)
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,4 +9,5 @@ using Test
     include("test_execute_on_input.jl")
     include("test_interpret.jl")
     include("test_call_func.jl")
+    include("test_make_interpreter.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using HerbInterpret
 using HerbInterpret: call_func
 using HerbCore
 using HerbGrammar
+using HerbSpecification
 using Test
 
 

--- a/test/test_execute_on_input.jl
+++ b/test/test_execute_on_input.jl
@@ -9,7 +9,7 @@ function create_dummy_grammar()
 end
 
 function create_dummy_rulenode()
-    return RuleNode(4,[RuleNode(3),RuleNode(1)])
+    return @rulenode 4{3,1}
 end
 
 

--- a/test/test_make_interpreter.jl
+++ b/test/test_make_interpreter.jl
@@ -1,0 +1,44 @@
+@testset "Test make_interpreter" begin
+    g = @cfgrammar begin
+        Number = |(1:2)
+        Number = x
+        Number = Number + Number
+        Number = Number * Number
+        Number = Number + 1
+        Number = x * 2
+    end
+
+    tags = HerbInterpret.get_relevant_tags(g)
+
+    @test tags[1] == 1
+    @test tags[2] == 2
+    @test tags[3] == :x
+    @test tags[4] == :+
+    @test tags[5] == :*
+    @test tags[6] == :(Number + 1)
+    @test tags[7] == :(x * 2)
+
+    input = Dict{Symbol,Any}(:x => 1)
+
+    ex = HerbInterpret.make_interpreter(g; input_symbols=[:x], name=:interpret_custom)
+
+    # Define interpret_custom *in this test module*
+    Core.eval(@__MODULE__, ex)
+
+    # Leaves
+    @test interpret_custom((@rulenode 1), tags, input) == 1
+    @test interpret_custom((@rulenode 2), tags, input) == 2
+    @test interpret_custom((@rulenode 3), tags, input) == 1
+
+    # Pure operators
+    @test interpret_custom((@rulenode 4{1,2}), tags, input) == 3           # 1 + 2
+    @test interpret_custom((@rulenode 5{1,2}), tags, input) == 2           # 1 * 2
+
+    # Partial rules
+    @test interpret_custom((@rulenode 6{3}), tags, input) == 2             # (x) + 1
+    @test interpret_custom((@rulenode 7), tags, input) == 2                # x * 2
+
+    # Your composite example: (x + 2) * (x * 2) with x=1 => (1+2)*(2)=6
+    rn = @rulenode 5{4{3,2},7}
+    @test interpret_custom(rn, tags, input) == 6
+end

--- a/test/test_make_interpreter.jl
+++ b/test/test_make_interpreter.jl
@@ -1,7 +1,46 @@
 import HerbInterpret: make_interpreter
 
+# Small module for testing state-less make_interpret
 module LocalStringDSL
     concat_cvc(a::String, b::String) = a * b
+end
+
+# Small module for testing state-ful make_stateful_interpret
+module LocalStateDSL
+    # very small "state" type for testing
+    struct St
+        x::Int
+    end
+
+    inc(st::St) = St(st.x + 1)
+    iseven(st::St) = Base.iseven(st.x)
+
+    function command_while(cond_node, body_node, st::St; max_steps::Int=100)
+        ctr = max_steps
+        while ctr > 0 && interpret_state(cond_node, st)
+            st = interpret_state(body_node, st)
+            ctr -= 1
+        end
+        return st
+    end
+end
+
+module LocalStateDSL2
+    struct St
+        x::Int
+    end
+    inc(st::St) = St(st.x + 1)
+    dec(st::St) = St(st.x - 1)
+    iseven(st::St) = Base.iseven(st.x)
+
+    using HerbGrammar
+    g2 = @cfgrammar begin
+        Start = Step
+        Step  = IF(Cond, Step, Step)
+        Step  = inc()
+        Step  = dec()
+        Cond  = iseven()
+    end
 end
 
 @testset verbose=true "Test make_interpreter" begin
@@ -138,4 +177,67 @@ end
         @test LocalStringDSL.interpret_string(rn, input) == "XA"
         @test concat_cvc("X", "A") == "X|A"
     end
+
+    @testset "Stateful interpreter generation" begin
+        # A tiny stateful grammar:
+        # 1: Start = Sequence
+        # 2: Sequence = Step
+        # 3: Sequence = (Step; Sequence)
+        # 4: Step = inc()
+        # 5: Step = IF(Cond, Step, Step)
+        # 6: Cond = iseven()
+        g = @cfgrammar begin
+            Start    = Sequence
+            Sequence = Step
+            Sequence = (Step; Sequence)
+            Step     = inc()
+            Step     = IF(Cond, Step, Step)
+            Cond     = iseven()
+        end
+
+        # Generate interpreter into LocalStateDSL
+        @make_stateful_interpreter g name=:interpret_state target_module=LocalStateDSL
+        @test isdefined(LocalStateDSL, :interpret_state)
+
+        # Program: (inc(); inc()) starting from x=0 => x=2
+        # Build rulenode for Sequence = (Step; Sequence):
+        prog_two_incs = @rulenode(1{3{4,2{4}}})
+
+        st0 = LocalStateDSL.St(0)
+        out = LocalStateDSL.interpret_state(prog_two_incs, st0)
+        @test out == LocalStateDSL.St(2)
+
+        # Vector-of-states overload
+        outs = LocalStateDSL.interpret_state(prog_two_incs, [LocalStateDSL.St(0), LocalStateDSL.St(10)])
+        @test outs == [LocalStateDSL.St(2), LocalStateDSL.St(12)]
+
+        # IF test:
+        # Step = IF(Cond, Step, Step)
+        # Build: IF(Cond=iseven(), Step=inc(), Step=inc())  -> regardless increments once,
+        
+        # Grammar is defined in external module
+        @make_stateful_interpreter LocalStateDSL2.g2 name=:interpret_state2 target_module=LocalStateDSL2
+
+        # IF(iseven(), inc(), dec())
+        # rule indices here:
+        # 1 Start=Step
+        # 2 Step=IF(Cond,Step,Step)
+        # 3 Step=inc()
+        # 4 Step=dec()
+        # 5 Cond=iseven()
+        prog_if = @rulenode(2{5,3,4})
+
+        @test LocalStateDSL2.interpret_state2(prog_if, LocalStateDSL2.St(2)) == LocalStateDSL2.St(3)  # even -> inc
+        @test LocalStateDSL2.interpret_state2(prog_if, LocalStateDSL2.St(3)) == LocalStateDSL2.St(2)  # odd  -> dec
+
+        # IOExample support:
+        exs = [
+            HerbSpecification.IOExample(Dict{Symbol,Any}(:_arg_1 => LocalStateDSL2.St(2)), nothing),
+            HerbSpecification.IOExample(Dict{Symbol,Any}(:_arg_1 => LocalStateDSL2.St(3)), nothing),
+        ]
+        outs_ex = LocalStateDSL2.interpret_state2(prog_if, exs)
+        @test outs_ex == [LocalStateDSL2.St(3), LocalStateDSL2.St(2)]
+    end
 end
+
+        rn = @rulenode(5{4{3,2},7})   

--- a/test/test_make_interpreter.jl
+++ b/test/test_make_interpreter.jl
@@ -1,39 +1,44 @@
 import HerbInterpret: make_interpreter
+using RuntimeGeneratedFunctions
+RuntimeGeneratedFunctions.init(@__MODULE__)
 
 # Small module for testing state-less make_interpret
 module LocalStringDSL
+    using HerbCore
+    using RuntimeGeneratedFunctions
+    RuntimeGeneratedFunctions.init(LocalStringDSL)
     concat_cvc(a::String, b::String) = a * b
 end
 
-# Small module for testing state-ful make_stateful_interpret
+# Simplest stateful grammar
 module LocalStateDSL
-    # very small "state" type for testing
+    using HerbCore
+    using RuntimeGeneratedFunctions
+    RuntimeGeneratedFunctions.init(LocalStateDSL)
+ 
     struct St
         x::Int
     end
 
     inc(st::St) = St(st.x + 1)
     iseven(st::St) = Base.iseven(st.x)
-
-    function command_while(cond_node, body_node, st::St; max_steps::Int=100)
-        ctr = max_steps
-        while ctr > 0 && interpret_state(cond_node, st)
-            st = interpret_state(body_node, st)
-            ctr -= 1
-        end
-        return st
-    end
 end
 
+# Stateful grammar with if-then-else
 module LocalStateDSL2
+    using HerbCore
+    using HerbGrammar
+    using RuntimeGeneratedFunctions
+    RuntimeGeneratedFunctions.init(LocalStateDSL2)
+ 
     struct St
         x::Int
     end
+
     inc(st::St) = St(st.x + 1)
     dec(st::St) = St(st.x - 1)
     iseven(st::St) = Base.iseven(st.x)
 
-    using HerbGrammar
     g2 = @cfgrammar begin
         Start = Step
         Step  = IF(Cond, Step, Step)
@@ -42,6 +47,29 @@ module LocalStateDSL2
         Cond  = iseven()
     end
 end
+
+# Stateful grammar with WHILE 
+module LocalStateDSL3
+    using HerbCore
+    using HerbGrammar
+    using RuntimeGeneratedFunctions
+    RuntimeGeneratedFunctions.init(LocalStateDSL3)
+ 
+    struct St
+        x::Int
+    end
+
+    inc(st::St) = St(st.x + 1)
+    lt3(st::St) = st.x < 3
+
+    g3 = @cfgrammar begin
+        Start = Step
+        Step  = WHILE(Cond, Step)
+        Step  = inc()
+        Cond  = lt3()
+    end
+end
+
 
 @testset verbose=true "Test make_interpreter" begin
     @testset "Test base functionality" begin
@@ -54,13 +82,13 @@ end
             Number = x * 2
         end
 
-        # Build and define the interpreter once for the next sub-testsets
-        ex = HerbInterpret.make_interpreter(g; input_symbols=[:x], name=:interpret_custom)
-        Core.eval(@__MODULE__, ex)
+        # Compile once
+        interpret_custom = HerbInterpret.make_interpreter(g; input_symbols=[:x])
 
-        @testset "Test make_interpreter on single input" begin
-            input = Dict{Symbol,Any}(:x => 1)
+        rn = @rulenode(5{4{3,2},7})  # (x + 2) * (x * 2)
+        input = Dict{Symbol,Any}(:x => 1)
 
+        @testset "Single input dict" begin
             # Leaves
             @test interpret_custom(@rulenode(1), input) == 1
             @test interpret_custom(@rulenode(2), input) == 2
@@ -74,90 +102,36 @@ end
             @test interpret_custom(@rulenode(6{3}), input) == 2     # x + 1
             @test interpret_custom(@rulenode(7), input) == 2        # x * 2
 
-            # Composite example: (x + 2) * (x * 2) with x=1 => 6
-            rn = @rulenode(5{4{3,2},7})
+            # Composite example
             @test interpret_custom(rn, input) == 6
         end
 
-        @testset "Test make_interpreter on multiple inputs" begin
-            rn = @rulenode(5{4{3,2},7})
-
+        @testset "Vector of input dicts" begin
             inputs = [
                 Dict{Symbol,Any}(:x => 1),
                 Dict{Symbol,Any}(:x => 3),
             ]
-
             outs = interpret_custom(rn, inputs)
+            @test outs == [6, 30]  # x=1 => 6, x=3 => 30
+        end
 
-            # x=1 => (1+2)*(2)=6
-            # x=3 => (3+2)*(6)=30
+        @testset "Single IOExample" begin
+            ex = HerbSpecification.IOExample(Dict{Symbol,Any}(:x => 1), nothing)
+            @test interpret_custom(rn, ex) == 6
+        end
+
+        @testset "Vector of IOExamples" begin
+            exs = [
+                HerbSpecification.IOExample(Dict{Symbol,Any}(:x => 1), nothing),
+                HerbSpecification.IOExample(Dict{Symbol,Any}(:x => 3), nothing),
+            ]
+            outs = interpret_custom(rn, exs)
             @test outs == [6, 30]
         end
     end
 
-    @testset "Test @make_interpreter macro forms" begin
-        g = @cfgrammar begin
-            Number = |(1:2)
-            Number = x
-            Number = Number + Number
-            Number = Number * Number
-            Number = Number + 1
-            Number = x * 2
-        end
-
-        rn = @rulenode(5{4{3,2},7})               # (x + 2) * (x * 2)
-        rn_without_input = @rulenode(5{4{1,2},2}) # (1 + 2) * 2
-        input = Dict{Symbol,Any}(:x => 1)
-
-        # We have to run all tests in a separate module to avoid overwriting existing functions and those warnings.
-        # We have to use Base.invokelatest to avoid world age issues here,a s the freshly generated binding is too new.
-        function run_in_fresh_module(expr_to_eval::Expr, fname::Symbol)
-            M = Module(gensym(:InterpTest))
-
-            # Make packages visible inside M
-            Core.eval(M, :(using HerbInterpret, HerbCore, HerbGrammar))
-
-            # Bind grammar inside M (so macro can reference `g`)
-            Core.eval(M, :(const g = $g))
-
-            # Run the macro call inside M
-            Core.eval(M, expr_to_eval)
-
-            # Return module and function name; we'll access/call via invokelatest
-            return M, fname
-        end
-
-        # @make_interpreter g  -> defines interpret
-        M, fname = run_in_fresh_module(:(@make_interpreter g), :interpret)
-        @test isdefined(M, :interpret)
-        f = getfield(M, :interpret)
-        @test Base.invokelatest(f, rn_without_input, Dict{Symbol,Any}()) == 6
-
-        # @make_interpreter g name=:interpret_sui
-        M, fname = run_in_fresh_module(:(@make_interpreter g name=:interpret_sui), :interpret_sui)
-        @test isdefined(M, :interpret_sui)
-        f = getfield(M, :interpret_sui)
-        @test Base.invokelatest(f, rn_without_input, Dict{Symbol,Any}()) == 6
-
-        # @make_interpreter g input_symbols=[:x]
-        M, fname = run_in_fresh_module(:(@make_interpreter g input_symbols=[:x]), :interpret)
-        @test isdefined(M, :interpret)
-        f = getfield(M, :interpret)
-        @test Base.invokelatest(f, rn, input) == 6
-
-        # @make_interpreter g name=:interpret_sui input_symbols=[:x]
-        M, fname = run_in_fresh_module(:(@make_interpreter g name=:interpret_sui input_symbols=[:x]), :interpret_sui)
-        @test isdefined(M, :interpret_sui)
-        f = getfield(M, :interpret_sui)
-        @test Base.invokelatest(f, rn, input) == 6
-
-        # Test the second function definition over multiple inputs
-        outs = Base.invokelatest(f, rn, [Dict{Symbol,Any}(:x => 1), Dict{Symbol,Any}(:x => 3)])
-        @test outs == [6, 30]
-    end
-
     @testset "Interpreter uses correct operators from target module" begin
-        # Conflicting operator in caller module
+        # Conflicting operator in caller module: must NOT be used
         concat_cvc(a::String, b::String) = a * "|" * b
 
         g = @cfgrammar begin
@@ -169,75 +143,115 @@ end
         rn = @rulenode(3{1,2})
         input = Dict{Symbol,Any}(:s => "X")
 
-        @make_interpreter g name=:interpret_string input_symbols=[:s] target_module=LocalStringDSL
+        # Compile once, but resolve operators in LocalStringDSL
+        interpret_string = HerbInterpret.make_interpreter(
+            g;
+            input_symbols=[:s],
+            target_module=LocalStringDSL,
+        )
 
-        @test isdefined(LocalStringDSL, :interpret_string)
-        @test !isdefined(@__MODULE__, :interpret_string)
+        # Dict form
+        @test interpret_string(rn, input) == "XA"
 
-        @test LocalStringDSL.interpret_string(rn, input) == "XA"
+        # IOExample form (optional extra check)
+        ex = HerbSpecification.IOExample(Dict{Symbol,Any}(:s => "X"), nothing)
+        @test interpret_string(rn, ex) == "XA"
+
+        # Prove caller's concat differs (and is not used)
         @test concat_cvc("X", "A") == "X|A"
     end
 
     @testset "Stateful interpreter generation" begin
-        # A tiny stateful grammar:
-        # 1: Start = Sequence
-        # 2: Sequence = Step
-        # 3: Sequence = (Step; Sequence)
-        # 4: Step = inc()
-        # 5: Step = IF(Cond, Step, Step)
-        # 6: Cond = iseven()
-        g = @cfgrammar begin
-            Start    = Sequence
-            Sequence = Step
-            Sequence = (Step; Sequence)
-            Step     = inc()
-            Step     = IF(Cond, Step, Step)
-            Cond     = iseven()
+        @testset "Test basic usage in external module" begin
+            # Rule indices:
+            # 1 Start    = Sequence
+            # 2 Sequence = Step
+            # 3 Sequence = (Step; Sequence)
+            # 4 Step     = inc()
+            # 5 Step     = IF(Cond, Step, Step)
+            # 6 Cond     = iseven()
+            g = @cfgrammar begin
+                Start    = Sequence
+                Sequence = Step
+                Sequence = (Step; Sequence)
+                Step     = inc()
+                Step     = IF(Cond, Step, Step)
+                Cond     = iseven()
+            end
+
+            # Build the interpreter object (RGF-backed)
+            interp = HerbInterpret.make_stateful_interpreter(
+                g;
+                target_module = LocalStateDSL,
+                cache_module  = @__MODULE__,
+            )
+
+            # Program: (inc(); inc()) starting from x=0 => x=2
+            # Start=Sequence -> Sequence=(Step;Sequence) -> Step=inc(); Sequence=Step -> Step=inc()
+            prog_two_incs = @rulenode(1{3{4,2{4}}})
+
+            st0 = LocalStateDSL.St(0)
+            out = interp(prog_two_incs, st0)
+            @test out == LocalStateDSL.St(2)
+
+            # Vector-of-states overload
+            outs = interp(prog_two_incs, [LocalStateDSL.St(0), LocalStateDSL.St(10)])
+            @test outs == [LocalStateDSL.St(2), LocalStateDSL.St(12)]
         end
 
-        # Generate interpreter into LocalStateDSL
-        @make_stateful_interpreter g name=:interpret_state target_module=LocalStateDSL
-        @test isdefined(LocalStateDSL, :interpret_state)
+        @testset "IF semantics in external target module" begin
+            # Build interpreter from grammar that lives in LocalStateDSL2
+            interp2 = HerbInterpret.make_stateful_interpreter(
+                LocalStateDSL2.g2;
+                target_module = LocalStateDSL2,
+                cache_module  = @__MODULE__,
+            )
 
-        # Program: (inc(); inc()) starting from x=0 => x=2
-        # Build rulenode for Sequence = (Step; Sequence):
-        prog_two_incs = @rulenode(1{3{4,2{4}}})
+            # Rule indices in LocalStateDSL2.g2:
+            # 1 Start=Step
+            # 2 Step=IF(Cond,Step,Step)
+            # 3 Step=inc()
+            # 4 Step=dec()
+            # 5 Cond=iseven()
 
-        st0 = LocalStateDSL.St(0)
-        out = LocalStateDSL.interpret_state(prog_two_incs, st0)
-        @test out == LocalStateDSL.St(2)
+            # IF(iseven(), inc(), dec())
+            prog_if = @rulenode(2{5,3,4})
 
-        # Vector-of-states overload
-        outs = LocalStateDSL.interpret_state(prog_two_incs, [LocalStateDSL.St(0), LocalStateDSL.St(10)])
-        @test outs == [LocalStateDSL.St(2), LocalStateDSL.St(12)]
+            @test interp2(prog_if, LocalStateDSL2.St(2)) == LocalStateDSL2.St(3)  # even -> inc
+            @test interp2(prog_if, LocalStateDSL2.St(3)) == LocalStateDSL2.St(2)  # odd  -> dec
 
-        # IF test:
-        # Step = IF(Cond, Step, Step)
-        # Build: IF(Cond=iseven(), Step=inc(), Step=inc())  -> regardless increments once,
-        
-        # Grammar is defined in external module
-        @make_stateful_interpreter LocalStateDSL2.g2 name=:interpret_state2 target_module=LocalStateDSL2
+            # IOExample support (state is in :_arg_1)
+            exs = [
+                HerbSpecification.IOExample(Dict{Symbol,Any}(:_arg_1 => LocalStateDSL2.St(2)), nothing),
+                HerbSpecification.IOExample(Dict{Symbol,Any}(:_arg_1 => LocalStateDSL2.St(3)), nothing),
+            ]
 
-        # IF(iseven(), inc(), dec())
-        # rule indices here:
-        # 1 Start=Step
-        # 2 Step=IF(Cond,Step,Step)
-        # 3 Step=inc()
-        # 4 Step=dec()
-        # 5 Cond=iseven()
-        prog_if = @rulenode(2{5,3,4})
+            outs_ex = interp2(prog_if, exs)
+            @test outs_ex == [LocalStateDSL2.St(3), LocalStateDSL2.St(2)]
+        end
 
-        @test LocalStateDSL2.interpret_state2(prog_if, LocalStateDSL2.St(2)) == LocalStateDSL2.St(3)  # even -> inc
-        @test LocalStateDSL2.interpret_state2(prog_if, LocalStateDSL2.St(3)) == LocalStateDSL2.St(2)  # odd  -> dec
+        @testset "WHILE operator (bounded loop) " begin
+            # Grammar lives in LocalStateDSL3.g3:
+            # 1 Start=Step
+            # 2 Step=WHILE(Cond, Step)
+            # 3 Step=inc()
+            # 4 Cond=lt3()
 
-        # IOExample support:
-        exs = [
-            HerbSpecification.IOExample(Dict{Symbol,Any}(:_arg_1 => LocalStateDSL2.St(2)), nothing),
-            HerbSpecification.IOExample(Dict{Symbol,Any}(:_arg_1 => LocalStateDSL2.St(3)), nothing),
-        ]
-        outs_ex = LocalStateDSL2.interpret_state2(prog_if, exs)
-        @test outs_ex == [LocalStateDSL2.St(3), LocalStateDSL2.St(2)]
+            interp3 = HerbInterpret.make_stateful_interpreter(
+                LocalStateDSL3.g3;
+                target_module = LocalStateDSL3,
+                cache_module  = @__MODULE__,
+            )
+
+            # WHILE(lt3(), inc())
+            prog_while = @rulenode(2{4,3})
+
+            @test interp3(prog_while, LocalStateDSL3.St(0)) == LocalStateDSL3.St(3)
+            @test interp3(prog_while, LocalStateDSL3.St(2)) == LocalStateDSL3.St(3)
+
+            # Vector-of-states
+            outs = interp3(prog_while, [LocalStateDSL3.St(0), LocalStateDSL3.St(1), LocalStateDSL3.St(3)])
+            @test outs == [LocalStateDSL3.St(3), LocalStateDSL3.St(3), LocalStateDSL3.St(3)]
+        end
     end
 end
-
-        rn = @rulenode(5{4{3,2},7})   

--- a/test/test_make_interpreter.jl
+++ b/test/test_make_interpreter.jl
@@ -1,44 +1,141 @@
-@testset "Test make_interpreter" begin
-    g = @cfgrammar begin
-        Number = |(1:2)
-        Number = x
-        Number = Number + Number
-        Number = Number * Number
-        Number = Number + 1
-        Number = x * 2
+import HerbInterpret: make_interpreter
+
+module LocalStringDSL
+    concat_cvc(a::String, b::String) = a * b
+end
+
+@testset verbose=true "Test make_interpreter" begin
+    @testset "Test base functionality" begin
+        g = @cfgrammar begin
+            Number = |(1:2)
+            Number = x
+            Number = Number + Number
+            Number = Number * Number
+            Number = Number + 1
+            Number = x * 2
+        end
+
+        # Build and define the interpreter once for the next sub-testsets
+        ex = HerbInterpret.make_interpreter(g; input_symbols=[:x], name=:interpret_custom)
+        Core.eval(@__MODULE__, ex)
+
+        @testset "Test make_interpreter on single input" begin
+            input = Dict{Symbol,Any}(:x => 1)
+
+            # Leaves
+            @test interpret_custom(@rulenode(1), input) == 1
+            @test interpret_custom(@rulenode(2), input) == 2
+            @test interpret_custom(@rulenode(3), input) == 1
+
+            # Pure operators
+            @test interpret_custom(@rulenode(4{1,2}), input) == 3   # 1 + 2
+            @test interpret_custom(@rulenode(5{1,2}), input) == 2   # 1 * 2
+
+            # Partial rules
+            @test interpret_custom(@rulenode(6{3}), input) == 2     # x + 1
+            @test interpret_custom(@rulenode(7), input) == 2        # x * 2
+
+            # Composite example: (x + 2) * (x * 2) with x=1 => 6
+            rn = @rulenode(5{4{3,2},7})
+            @test interpret_custom(rn, input) == 6
+        end
+
+        @testset "Test make_interpreter on multiple inputs" begin
+            rn = @rulenode(5{4{3,2},7})
+
+            inputs = [
+                Dict{Symbol,Any}(:x => 1),
+                Dict{Symbol,Any}(:x => 3),
+            ]
+
+            outs = interpret_custom(rn, inputs)
+
+            # x=1 => (1+2)*(2)=6
+            # x=3 => (3+2)*(6)=30
+            @test outs == [6, 30]
+        end
     end
 
-    tags = HerbInterpret.get_relevant_tags(g)
+    @testset "Test @make_interpreter macro forms" begin
+        g = @cfgrammar begin
+            Number = |(1:2)
+            Number = x
+            Number = Number + Number
+            Number = Number * Number
+            Number = Number + 1
+            Number = x * 2
+        end
 
-    @test tags[1] == 1
-    @test tags[2] == 2
-    @test tags[3] == :x
-    @test tags[4] == :+
-    @test tags[5] == :*
-    @test tags[6] == :(Number + 1)
-    @test tags[7] == :(x * 2)
+        rn = @rulenode(5{4{3,2},7})               # (x + 2) * (x * 2)
+        rn_without_input = @rulenode(5{4{1,2},2}) # (1 + 2) * 2
+        input = Dict{Symbol,Any}(:x => 1)
 
-    input = Dict{Symbol,Any}(:x => 1)
+        # We have to run all tests in a separate module to avoid overwriting existing functions and those warnings.
+        # We have to use Base.invokelatest to avoid world age issues here,a s the freshly generated binding is too new.
+        function run_in_fresh_module(expr_to_eval::Expr, fname::Symbol)
+            M = Module(gensym(:InterpTest))
 
-    ex = HerbInterpret.make_interpreter(g; input_symbols=[:x], name=:interpret_custom)
+            # Make packages visible inside M
+            Core.eval(M, :(using HerbInterpret, HerbCore, HerbGrammar))
 
-    # Define interpret_custom *in this test module*
-    Core.eval(@__MODULE__, ex)
+            # Bind grammar inside M (so macro can reference `g`)
+            Core.eval(M, :(const g = $g))
 
-    # Leaves
-    @test interpret_custom((@rulenode 1), tags, input) == 1
-    @test interpret_custom((@rulenode 2), tags, input) == 2
-    @test interpret_custom((@rulenode 3), tags, input) == 1
+            # Run the macro call inside M
+            Core.eval(M, expr_to_eval)
 
-    # Pure operators
-    @test interpret_custom((@rulenode 4{1,2}), tags, input) == 3           # 1 + 2
-    @test interpret_custom((@rulenode 5{1,2}), tags, input) == 2           # 1 * 2
+            # Return module and function name; we'll access/call via invokelatest
+            return M, fname
+        end
 
-    # Partial rules
-    @test interpret_custom((@rulenode 6{3}), tags, input) == 2             # (x) + 1
-    @test interpret_custom((@rulenode 7), tags, input) == 2                # x * 2
+        # @make_interpreter g  -> defines interpret
+        M, fname = run_in_fresh_module(:(@make_interpreter g), :interpret)
+        @test isdefined(M, :interpret)
+        f = getfield(M, :interpret)
+        @test Base.invokelatest(f, rn_without_input, Dict{Symbol,Any}()) == 6
 
-    # Your composite example: (x + 2) * (x * 2) with x=1 => (1+2)*(2)=6
-    rn = @rulenode 5{4{3,2},7}
-    @test interpret_custom(rn, tags, input) == 6
+        # @make_interpreter g name=:interpret_sui
+        M, fname = run_in_fresh_module(:(@make_interpreter g name=:interpret_sui), :interpret_sui)
+        @test isdefined(M, :interpret_sui)
+        f = getfield(M, :interpret_sui)
+        @test Base.invokelatest(f, rn_without_input, Dict{Symbol,Any}()) == 6
+
+        # @make_interpreter g input_symbols=[:x]
+        M, fname = run_in_fresh_module(:(@make_interpreter g input_symbols=[:x]), :interpret)
+        @test isdefined(M, :interpret)
+        f = getfield(M, :interpret)
+        @test Base.invokelatest(f, rn, input) == 6
+
+        # @make_interpreter g name=:interpret_sui input_symbols=[:x]
+        M, fname = run_in_fresh_module(:(@make_interpreter g name=:interpret_sui input_symbols=[:x]), :interpret_sui)
+        @test isdefined(M, :interpret_sui)
+        f = getfield(M, :interpret_sui)
+        @test Base.invokelatest(f, rn, input) == 6
+
+        # Test the second function definition over multiple inputs
+        outs = Base.invokelatest(f, rn, [Dict{Symbol,Any}(:x => 1), Dict{Symbol,Any}(:x => 3)])
+        @test outs == [6, 30]
+    end
+
+    @testset "Interpreter uses correct operators from target module" begin
+        # Conflicting operator in caller module
+        concat_cvc(a::String, b::String) = a * "|" * b
+
+        g = @cfgrammar begin
+            Str = s
+            Str = "A"
+            Str = concat_cvc(Str, Str)
+        end
+
+        rn = @rulenode(3{1,2})
+        input = Dict{Symbol,Any}(:s => "X")
+
+        @make_interpreter g name=:interpret_string input_symbols=[:s] target_module=LocalStringDSL
+
+        @test isdefined(LocalStringDSL, :interpret_string)
+        @test !isdefined(@__MODULE__, :interpret_string)
+
+        @test LocalStringDSL.interpret_string(rn, input) == "XA"
+        @test concat_cvc("X", "A") == "X|A"
+    end
 end


### PR DESCRIPTION
- added an interpret generator that works on arbitrary inputs
- interpret generator now also works on composite expressions
- interpret generator now allows for custom naming and custom input symbols (which have to be given explicitly)
- added tests for tags and interpret generator