### PR TITLE
Fix typo in `make_stateful_interpreter` export

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,19 +7,11 @@ authors = ["Tilman Hinnerichs <t.r.hinnerichs@tudelft.nl>", "Jaap de Jong <jaapd
 HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
 HerbGrammar = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
 HerbSpecification = "6d54aada-062f-46d8-85cf-a1ceaf058a06"
-MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 RuntimeGeneratedFunctions = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 
 [compat]
 HerbCore = "1"
 HerbGrammar = "1"
 HerbSpecification = "1"
-MLStyle = "0.4.17"
 RuntimeGeneratedFunctions = "0.5.16"
 julia = "1.10"
-
-[extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "HerbInterpret"
 uuid = "5bbddadd-02c5-4713-84b8-97364418cca7"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Tilman Hinnerichs <t.r.hinnerichs@tudelft.nl>", "Jaap de Jong <jaapdejong15@gmail.com>", "Sebastijan Dumancic <s.dumancic@tudelft.nl>", "Reuben Gardos Reid <R.J.GardosReid@tudelft.nl>"]
 
 [deps]

--- a/src/HerbInterpret.jl
+++ b/src/HerbInterpret.jl
@@ -14,7 +14,7 @@ export
     execute_on_input,
 
     make_interpreter,
-    @make_stateful_interpreter,
+    make_stateful_interpreter,
     build_match_cases,
     build_match_cases_stateful
 end # module HerbInterpret

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+HerbCore = "2b23ba43-8213-43cb-b5ea-38c12b45bd45"
+HerbGrammar = "4ef9e186-2fe5-4b24-8de7-9f7291f24af7"
+HerbSpecification = "6d54aada-062f-46d8-85cf-a1ceaf058a06"
+RuntimeGeneratedFunctions = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Aqua
 using HerbInterpret
 using HerbInterpret: call_func
 using HerbCore
@@ -6,7 +7,8 @@ using HerbSpecification
 using Test
 
 
-@testset verbose=true "HerbInterpret.jl" begin
+@testset verbose = true "HerbInterpret.jl" begin
+    @testset "Aqua" Aqua.test_all(HerbInterpret)
     include("test_execute_on_input.jl")
     include("test_interpret.jl")
     include("test_call_func.jl")


### PR DESCRIPTION
Include `Aqua` to test for errors like this within `HerbInterpret` (only caught the undefined export in the test pipeline for `Herb.jl`)