### PR TITLE
Let generated interpreters handle 'nothing' values.

### DIFF
--- a/src/HerbInterpret.jl
+++ b/src/HerbInterpret.jl
@@ -14,6 +14,7 @@ export
     execute_on_input,
 
     make_interpreter,
+    make_output_interpreter,
     make_stateful_interpreter,
     build_match_cases,
     build_match_cases_stateful

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -151,7 +151,7 @@ end
 function (gi::GeneratedOutputInterpreter)(rule::Int,
                                    children_outputs::AbstractVector{<:AbstractVector{<:Any}},
                                    inputs::AbstractVector{<:AbstractDict{Symbol,Any}})
-    return (gi.core).((gi.core,), (rule,), children_outputs, inputs)   # broadcasts (self, prog, input)
+    return [gi.core(gi.core, rule, [outputs[index] for outputs in children_outputs], input) for (index, input) in enumerate(inputs)]
 end
 
 function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
@@ -173,11 +173,7 @@ end
 function (gi::GeneratedOutputInterpreter)(rule::Int,
                                    children_outputs::AbstractVector{<:AbstractVector{<:Any}},
                                    exs::AbstractVector{<:HerbSpecification.IOExample})
-    if isempty(children_outputs)
-        return [gi(rule, [], ex) for ex in exs]
-    else
-        return [gi(rule, outputs, ex) for (outputs, ex) in zip(children_outputs, exs)]
-    end
+    return [gi(rule, [outputs[index] for outputs in children_outputs], ex) for (index, ex) in enumerate(exs)]
 end
 
 #

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -176,6 +176,13 @@ function (gi::GeneratedOutputInterpreter)(rule::Int,
     return [gi(rule, outputs, ex) for (outputs, ex) in zip(children_outputs, exs)]
 end
 
+function (gi::GeneratedOutputInterpreter)(rule::Int,
+                                   children_outputs::AbstractVector{<:Any},
+                                   exs::AbstractVector{<:HerbSpecification.IOExample})
+    @assert isempty(children_outputs)
+    return [gi(rule, [], ex) for ex in exs]
+end
+
 
 """
     make_interpreter(grammar::AbstractGrammar; input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing, target_module::Module = @__MODULE__, cache_module::Module = HerbInterpret)

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -110,6 +110,8 @@ function build_match_cases(
     input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing,
 )
     input_set = input_symbols === nothing ? nothing : Set(input_symbols)
+    
+    nonterminals = Set{Symbol}(t for t in grammar.types if t !== nothing)
 
     # recurse on child i as: c[i]
     recur(i) = :( c[$i] )

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -126,10 +126,20 @@ struct GeneratedInterpreter{F}
     core::F
 end
 
+struct GeneratedOutputInterpreter{F}
+    core::F
+end
+
 # Single input
 function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
                                    input::AbstractDict{Symbol,Any})
     return gi.core(gi.core, prog, input)
+end
+
+function (gi::GeneratedOutputInterpreter)(rule::Int,
+                                   children_outputs::AbstractVector{<:Any},
+                                   input::AbstractDict{Symbol,Any})
+    return gi.core(gi.core, rule, children_outputs, input)
 end
 
 # Vector of inputs
@@ -138,14 +148,32 @@ function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
     return (gi.core).((gi.core,), (prog,), inputs)   # broadcasts (self, prog, input)
 end
 
+function (gi::GeneratedOutputInterpreter)(rule::Int,
+                                   children_outputs::AbstractVector{<:AbstractVector{<:Any}},
+                                   inputs::AbstractVector{<:AbstractDict{Symbol,Any}})
+    return (gi.core).((gi.core,), (rule,), children_outputs, inputs)   # broadcasts (self, prog, input)
+end
+
 function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
                                    ex::HerbSpecification.IOExample)
     return gi(prog, ex.in)
 end
 
+function (gi::GeneratedOutputInterpreter)(rule::Int,
+                                   children_outputs::AbstractVector{<:Any},
+                                   ex::HerbSpecification.IOExample)
+    return gi(rule, children_outputs, ex.in)
+end
+
 function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
                                    exs::AbstractVector{<:HerbSpecification.IOExample})
     return [gi(prog, ex) for ex in exs]
+end
+
+function (gi::GeneratedOutputInterpreter)(rule::Int,
+                                   children_outputs::AbstractVector{<:AbstractVector{<:Any}},
+                                   exs::AbstractVector{<:HerbSpecification.IOExample})
+    return [gi(rule, outputs, ex) for (outputs, ex) in zip(children_outputs, exs)]
 end
 
 
@@ -211,6 +239,39 @@ function make_interpreter(grammar::AbstractGrammar;
     # Call RuntimeGeneratedFunction on this, so we can directly use it
     core = RuntimeGeneratedFunctions.RuntimeGeneratedFunction(cache_module, target_module, ex)
     return GeneratedInterpreter(core)
+end
+
+
+function make_output_interpreter(grammar::AbstractGrammar;
+    input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing,
+    target_module::Module = @__MODULE__,
+    cache_module::Module = HerbInterpret
+)
+    # ensure the cache exists in the chosen cache module
+    RuntimeGeneratedFunctions.init(cache_module)
+
+    # build if-then-else statements to evaluate the expressions
+    branches = build_match_cases(grammar;
+        target_module = target_module,
+        input_symbols = input_symbols
+    )
+
+    # Add error for non-existent indices
+    cascade = Expr(:block, branches..., :(error("No matching rule index: ", r)))
+
+    # Bit of meta-programming magic:
+    # Constructs an anonymous function with an extra self arg for recursion.
+    ex = :(function (self, rule, children_outputs, input)
+        r = rule
+        c = children_outputs
+        any(isnothing, c) && return nothing
+        $cascade
+    end)
+    Base.remove_linenums!(ex)
+
+    # Call RuntimeGeneratedFunction on this, so we can directly use it
+    core = RuntimeGeneratedFunctions.RuntimeGeneratedFunction(cache_module, target_module, ex)
+    return GeneratedOutputInterpreter(core)
 end
 
 

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -245,11 +245,9 @@ end
     make_interpreter(grammar::AbstractGrammar; input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing, target_module::Module = @__MODULE__, cache_module::Module = HerbInterpret)
 
 
-Construct a fast, *runtime-generated* interpreter for programs represented as
-`HerbCore.AbstractRuleNode`s.
+Constructs a fast, runtime-generated interpreter for programs represented as `HerbCore.AbstractRuleNode`s.
 
-The returned value is a callable `GeneratedInterpreter` (a small wrapper around a
-`RuntimeGeneratedFunctions.RuntimeGeneratedFunction`) that can be applied to:
+The returned value is a callable `GeneratedInterpreter` (a small wrapper around a `RuntimeGeneratedFunctions.RuntimeGeneratedFunction`) that can be applied to:
 
 - a single input dictionary:
   `interp(prog, input::AbstractDict{Symbol,Any})`
@@ -267,11 +265,11 @@ The returned value is a callable `GeneratedInterpreter` (a small wrapper around 
 
 ## Keyword arguments
 
-- `input_symbols`: Optional list of symbols that should be interpreted as *inputs*.  If provided, terminals matching these symbols (and any symbol following the `_arg_` convention) are read from the `input` dict.
+- `input_symbols`: Optional list of symbols that should be interpreted as inputs.  If provided, terminals matching these symbols (and any symbol following the `_arg_X` convention) are read from the `input` dict.
 
 - `target_module`: Module in which operator/function symbols appearing in the grammar are resolved. This is important when the grammar uses domain-specific primitives (e.g. `concat_cvc`, `substr_cvc`) that are defined in a benchmark module rather than in the caller’s module.
 
-- `cache_module`: Module used by `RuntimeGeneratedFunctions.jl` to store its internal cache. 
+- `cache_module`: Module used by `RuntimeGeneratedFunctions.jl` to store its internal cachen. 
 """
 function make_interpreter(grammar::AbstractGrammar;
     input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing,

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -43,8 +43,8 @@ function build_match_cases(
 )
     input_set = input_symbols === nothing ? nothing : Set(input_symbols)
 
-    # recurse on child i as: self(self, c[i], input)
-    recur(i) = :( self(self, c[$i], input) )
+    # recurse on child i as: c[i]
+    recur(i) = :( c[$i] )
 
     # Emit code to evaluate a rule RHS, consuming children c[i] for nonterminals.
     function emit_eval(x, next_child::Base.RefValue{Int})
@@ -202,7 +202,8 @@ function make_interpreter(grammar::AbstractGrammar;
     # Constructs an anonymous function with an extra self arg for recursion.
     ex = :(function (self, prog, input)
         r = HerbCore.get_rule(prog)
-        c = HerbCore.get_children(prog)
+        c = [self(self, child, input) for child in get_children(prog)]
+        any(isnothing, c) && return nothing
         $cascade
     end)
     Base.remove_linenums!(ex)

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -23,6 +23,60 @@ function _qualify(target_module::Module, f)
     return f isa Symbol ? GlobalRef(target_module, f) : f
 end
 
+"""
+    _collect_lambda_args(lhs)
+
+Return the flat list of variables bound by a lambda lhs.
+
+Supports:
+```
+- x
+- (x, y)
+- x::T
+- (x::T, y::S)
+- varargs like x...
+```
+
+Concretely this supports the following examples:
+```
+x -> Func(x)
+(x) -> Func(x)
+(x::Int) -> x + 1
+(x, y) -> x + y
+(x::Int, y::Int) -> x * y
+(xs...) -> sum(xs)
+(x, ys...) -> x + length(ys)
+```
+
+But not:
+```
+() -> 1                 # zero-arg lambda
+((x, y), z) -> x + z    # destructuring / nested tuple patterns
+(; x=1) -> x            # keyword-style parameter forms
+```
+"""
+function _collect_lambda_args(lhs)
+    if lhs isa Symbol
+        return Symbol[lhs]
+
+    elseif lhs isa Expr
+        if lhs.head == :(::)
+            return _collect_lambda_args(lhs.args[1])
+
+        elseif lhs.head == :tuple
+            out = Symbol[]
+            for a in lhs.args
+                append!(out, _collect_lambda_args(a))
+            end
+            return out
+
+        elseif lhs.head == :...
+            return _collect_lambda_args(lhs.args[1])
+        end
+    end
+
+    throw(ArgumentError("Unsupported lambda argument syntax: $lhs"))
+end
 
 """
     build_match_cases(grammar; target_module=@__MODULE__, input_symbols=nothing)
@@ -35,6 +89,20 @@ These branches are intended to be spliced into a block after
 `r = get_rule(prog); c = get_children(prog)`.
 
 Returns a vector of branching expressions.
+
+Is based on `emit_eval`, which translates nested rules like
+```
+Number = Number + 1
+```
+into
+```
+Expr(:call,
+     GlobalRef(target_module, :+),
+     :(self(self, c[1], input)),
+     1)
+```
+which denotes the intended operation within the target module applied to the evaluation result of the children, here `c[1]`.
+
 """
 function build_match_cases(
     grammar::AbstractGrammar;
@@ -43,13 +111,22 @@ function build_match_cases(
 )
     input_set = input_symbols === nothing ? nothing : Set(input_symbols)
 
+    nonterminals = Set{Symbol}(t for t in grammar.types if t !== nothing)
+
     # recurse on child i as: self(self, c[i], input)
     recur(i) = :( self(self, c[$i], input) )
 
-    # Emit code to evaluate a rule RHS, consuming children c[i] for nonterminals.
-    function emit_eval(x, next_child::Base.RefValue{Int})
+    # `bound` is needed to lambda values apart from grammar symbols and globals
+    # `next_child` denotes which child to consume next.
+    function emit_eval(
+        x,
+        next_child::Base.RefValue{Int},
+        bound::Set{Symbol} = Set{Symbol}(),
+    )
         if x isa Symbol
-            if x in grammar.types
+            if x in bound
+                return x
+            elseif x in nonterminals
                 i = next_child[]
                 next_child[] += 1
                 return recur(i)
@@ -58,18 +135,32 @@ function build_match_cases(
             else
                 return GlobalRef(target_module, x)
             end
+
         elseif x isa Expr
-            if x.head == :call
-                f = _qualify(target_module, x.args[1])
-                args = [emit_eval(a, next_child) for a in x.args[2:end]]
+            # x is a lambda function
+            if x.head == :->
+                lhs = x.args[1]
+                rhs = x.args[2]
+
+                bound2 = copy(bound)
+                union!(bound2, _collect_lambda_args(lhs))
+
+                return Expr(:->, lhs, emit_eval(rhs, next_child, bound2))
+            # x is a function call
+            elseif x.head == :call
+                f = emit_eval(x.args[1], next_child, bound)
+                args = [emit_eval(a, next_child, bound) for a in x.args[2:end]]
                 return Expr(:call, f, args...)
+
+            # x is an if-then-else block
             elseif x.head == :if
-                cond = emit_eval(x.args[1], next_child)
-                tbr  = emit_eval(x.args[2], next_child)
-                fbr  = emit_eval(x.args[3], next_child)
+                cond = emit_eval(x.args[1], next_child, bound)
+                tbr  = emit_eval(x.args[2], next_child, bound)
+                fbr  = emit_eval(x.args[3], next_child, bound)
                 return Expr(:if, cond, tbr, fbr)
+
             else
-                return Expr(x.head, (emit_eval(a, next_child) for a in x.args)...)
+                return Expr(x.head, (emit_eval(a, next_child, bound) for a in x.args)...)
             end
         else
             return x
@@ -87,24 +178,25 @@ function build_match_cases(
 
             pure =
                 (op isa Symbol) &&
-                all(a -> (a isa Symbol) && (a in grammar.types), args)
+                !(op in nonterminals) &&
+                all(a -> (a isa Symbol) && (a in nonterminals), args)
 
             if pure
                 nargs = length(args)
                 child_vals = [recur(i) for i in 1:nargs]
-                rhs_code = Expr(:call, _qualify(target_module, op), child_vals...)
+                rhs_code = Expr(:call, GlobalRef(target_module, op), child_vals...)
             else
                 nxt = Ref(1)
                 rhs_code = emit_eval(rhs_rule, nxt)
             end
 
-        elseif rhs_rule isa Expr && rhs_rule.head == :if
+        elseif rhs_rule isa Expr
             nxt = Ref(1)
             rhs_code = emit_eval(rhs_rule, nxt)
 
         elseif rhs_rule isa Symbol
-            if rhs_rule in grammar.types
-                rhs_code = recur(1)  # Start = Number  etc.
+            if rhs_rule in nonterminals
+                rhs_code = recur(1)
             elseif _is_input_tag(rhs_rule, input_set)
                 rhs_code = :( input[$(QuoteNode(rhs_rule))] )
             else
@@ -214,44 +306,79 @@ end
 
 
 """
-    build_match_cases_stateful_rgf(grammar; target_module=@__MODULE__, state_name=:state, max_steps=1000)
+    build_match_cases_stateful(grammar; target_module=@__MODULE__, state_name=:state, max_steps=1000)
 
-Like `build_match_cases_stateful`, but emits code for a RuntimeGeneratedFunction body:
-- recursion is expressed as `self(self, child, state)`
-- `WHILE` is inlined (bounded by `max_steps`) to avoid needing external helpers
+Build guarded return branches for a state-threading interpreter over
+`HerbCore.AbstractRuleNode`s.
+
+The generated code assumes a function body with local variables
+
+    r = HerbCore.get_rule(prog)
+    c = HerbCore.get_children(prog)
+
+and returns expressions of the form
+
+    r == k && return <rhs>
+
+Semantics:
+- nonterminals recurse as `self(self, c[i], state)`
+- sequencing `(A; B)` threads state left-to-right
+- `IF(cond, t, f)` and `WHILE(cond, body)` are handled specially
+- ordinary named calls in DSL rules receive `state` implicitly
+- lambda bodies are rewritten as pure expressions, with bound variables
+  tracked so they are not mistaken for globals or nonterminals
+
+`target_module` is the module in which terminal symbols and primitive
+functions are resovled, `state_name` is the threaded state variable name,
+and `max_steps` bounds generated `WHILE` loops.
 """
 function build_match_cases_stateful(
-        grammar::AbstractGrammar;
-        target_module::Module = @__MODULE__,
-        state_name::Symbol = :state,
-    )
+    grammar::AbstractGrammar;
+    target_module::Module = @__MODULE__,
+    state_name::Symbol = :state,
+    max_steps::Int = 1000,
+)
     branches = Expr[]
-    max_steps=1000
+
+    nonterminals = Set{Symbol}(t for t in grammar.types if t !== nothing)
 
     # recurse into i-th child with threaded state
     child_call(i) = :( self(self, c[$i], $(state_name)) )
 
-    for (ind, rhs_rule) in pairs(grammar.rules)
-        rhs_code = nothing
+    function emit_eval(
+        x,
+        next_child::Base.RefValue{Int},
+        bound::Set{Symbol} = Set{Symbol}();
+        implicit_state::Bool = true,
+    )
+        if x isa Symbol
+            if x in bound
+                return x
+            elseif x in nonterminals
+                i = next_child[]
+                next_child[] += 1
+                return child_call(i)
+            else
+                return GlobalRef(target_module, x)
+            end
 
-        if rhs_rule isa Expr
-            if rhs_rule.head == :block
-                # (A; B) sequencing
-                rhs_code = :( self(self, c[2], self(self, c[1], $(state_name))) )
+        elseif x isa Expr
+            # sequencing: (A; B)
+            if implicit_state && x.head == :block
+                return :( self(self, c[2], self(self, c[1], $(state_name))) )
 
-            elseif rhs_rule.head == :call && rhs_rule.args[1] == :(;)
-                # alternative encoding of sequencing
-                rhs_code = :( self(self, c[2], self(self, c[1], $(state_name))) )
+            elseif implicit_state && x.head == :call && x.args[1] == :(;)
+                return :( self(self, c[2], self(self, c[1], $(state_name))) )
 
-            elseif rhs_rule.head == :call && rhs_rule.args[1] == :IF
-                rhs_code = :( self(self, c[1], $(state_name)) ?
-                              self(self, c[2], $(state_name)) :
-                              self(self, c[3], $(state_name)) )
+            # IF(cond, then, else)
+            elseif implicit_state && x.head == :call && x.args[1] == :IF
+                return :( self(self, c[1], $(state_name)) ?
+                          self(self, c[2], $(state_name)) :
+                          self(self, c[3], $(state_name)) )
 
-            elseif rhs_rule.head == :call && rhs_rule.args[1] == :WHILE
-                # Inline a bounded while-loop:
-                # WHILE(cond, body)
-                rhs_code = quote
+            # WHILE(cond, body)
+            elseif implicit_state && x.head == :call && x.args[1] == :WHILE
+                return quote
                     local st  = $(state_name)
                     local ctr = $(max_steps)
                     while ctr > 0 && self(self, c[1], st)
@@ -261,35 +388,91 @@ function build_match_cases_stateful(
                     st
                 end
 
-            elseif rhs_rule.head == :call
-                f    = rhs_rule.args[1]
-                args = rhs_rule.args[2:end]
+            # lambda
+            elseif x.head == :->
+                lhs = x.args[1]
+                rhs = x.args[2]
 
-                # Most stateful primitives are 0-arg: inc(), moveRight(), etc.
-                if isempty(args)
-                    rhs_code = Expr(:call, _qualify(target_module, f), state_name)
-                else
-                    # For calls with nonterminals, interpret children and pass results
-                    nargs      = length(args)
-                    child_vals = [child_call(i) for i in 1:nargs]
-                    rhs_code   = Expr(:call, _qualify(target_module, f), child_vals...)
-                end
+                bound2 = copy(bound)
+                union!(bound2, _collect_lambda_args(lhs))
+
+                # lambda bodies are treated as ordinary pure expressions
+                return Expr(:->, lhs, emit_eval(rhs, next_child, bound2; implicit_state=false))
+
+            # generic function call
+            elseif x.head == :call
+                f_raw = x.args[1]
+                f = emit_eval(f_raw, next_child, bound; implicit_state=implicit_state)
+                args = [emit_eval(a, next_child, bound; implicit_state=implicit_state) for a in x.args[2:end]]
+
+                # In stateful mode, a named global call gets `state` appended.
+                # This makes:
+                #   inc()       -> inc(state)
+                #   apply(Func) -> apply(f, state)
+                #
+                # But calls through lambdas / nonterminal-produced functions
+                # do NOT get state appended.
+                needs_state =
+                    implicit_state &&
+                    (f_raw isa Symbol) &&
+                    !(f_raw in bound) &&
+                    !(f_raw in nonterminals)
+
+                return needs_state ?
+                    Expr(:call, f, args..., state_name) :
+                    Expr(:call, f, args...)
+
             else
-                # fallback: forward to first child
-                rhs_code = :( self(self, c[1], $(state_name)) )
+                return Expr(
+                    x.head,
+                    (emit_eval(a, next_child, bound; implicit_state=implicit_state) for a in x.args)...,
+                )
+            end
+        else
+            return x
+        end
+    end
+
+    for (ind, rhs_rule) in pairs(grammar.rules)
+        rhs_code = nothing
+
+        if rhs_rule isa Expr && rhs_rule.head == :call
+            op   = rhs_rule.args[1]
+            args = rhs_rule.args[2:end]
+
+            pure =
+                (op isa Symbol) &&
+                !(op in nonterminals) &&
+                op != :IF &&
+                op != :WHILE &&
+                op != :(;) &&
+                all(a -> (a isa Symbol) && (a in nonterminals), args)
+
+            if pure
+                nargs = length(args)
+                child_vals = [child_call(i) for i in 1:nargs]
+
+                # stateful named calls receive state as final arg
+                rhs_code = Expr(:call, GlobalRef(target_module, op), child_vals..., state_name)
+            else
+                nxt = Ref(1)
+                rhs_code = emit_eval(rhs_rule, nxt)
             end
 
+        elseif rhs_rule isa Expr
+            nxt = Ref(1)
+            rhs_code = emit_eval(rhs_rule, nxt)
+
         elseif rhs_rule isa Symbol
-            if rhs_rule in grammar.types
-                # Alias: Start = Sequence, etc.
-                rhs_code = :( self(self, c[1], $(state_name)) )
+            if rhs_rule in nonterminals
+                # alias: Start = Step, etc.
+                rhs_code = child_call(1)
             else
-                # Rare: terminal symbol treated as primitive on state
-                rhs_code = Expr(:call, _qualify(target_module, rhs_rule), state_name)
+                # bare terminal symbol is a value/function, not a stateful primitive
+                rhs_code = GlobalRef(target_module, rhs_rule)
             end
 
         else
-            # literal terminal
             rhs_code = rhs_rule
         end
 
@@ -298,7 +481,6 @@ function build_match_cases_stateful(
 
     return branches
 end
-
 
 struct GeneratedStatefulInterpreter{F}
     core::F  # RuntimeGeneratedFunction
@@ -327,14 +509,28 @@ end
 
 
 """
-    make_stateful_interpreter_rgf(grammar; target_module=@__MODULE__, cache_module=HerbInterpret, max_steps=1000)
+    make_stateful_interpreter(grammar::AbstractGrammar;
+        target_module::Module = @__MODULE__,
+        cache_module::Module  = HerbInterpret,
+    )
 
-Build a RuntimeGeneratedFunctions-backed state-threading interpreter.
+Build a fast runtime-generated interpreter for state-threading DSLs over
+`HerbCore.AbstractRuleNode`s.
 
-- `target_module` controls where primitives (inc, moveRight, etc.) are resolved.
-- `cache_module` controls where RGF stores its cache. **This module must have**
-  `RuntimeGeneratedFunctions.init(@__MODULE__)` executed at module top level.
-- `max_steps` bounds generated WHILE loops.
+The returned `GeneratedStatefulInterpreter` supports:
+
+- `interp(prog, state)`
+- `interp(prog, states::AbstractVector)`
+- `interp(prog, ex::HerbSpecification.IOExample)` using `ex.in[:_arg_1]`
+- `interp(prog, exs::AbstractVector{<:HerbSpecification.IOExample})`
+
+The interpreter threads state through recursive child evaluation, supports
+sequencing, conditionals, and bounded `WHILE` loops, and resolves grammar
+primitives in `target_module`.
+
+`cache_module` is the module used by `RuntimeGeneratedFunctions.jl` for its
+internal cache and must be initialized with
+`RuntimeGeneratedFunctions.init(@__MODULE__)` at module top level.
 """
 function make_stateful_interpreter(
         grammar::AbstractGrammar;

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -173,16 +173,16 @@ end
 function (gi::GeneratedOutputInterpreter)(rule::Int,
                                    children_outputs::AbstractVector{<:AbstractVector{<:Any}},
                                    exs::AbstractVector{<:HerbSpecification.IOExample})
-    return [gi(rule, outputs, ex) for (outputs, ex) in zip(children_outputs, exs)]
+    if isempty(children_outputs)
+        return [gi(rule, [], ex) for ex in exs]
+    else
+        return [gi(rule, outputs, ex) for (outputs, ex) in zip(children_outputs, exs)]
+    end
 end
 
-function (gi::GeneratedOutputInterpreter)(rule::Int,
-                                   children_outputs::AbstractVector{<:Any},
-                                   exs::AbstractVector{<:HerbSpecification.IOExample})
-    @assert isempty(children_outputs)
-    return [gi(rule, [], ex) for ex in exs]
-end
-
+#
+#   Vector{Any}[]
+#   Vector{IOExample{Any, String}}
 
 """
     make_interpreter(grammar::AbstractGrammar; input_symbols::Union{Nothing,AbstractVector{Symbol}} = nothing, target_module::Module = @__MODULE__, cache_module::Module = HerbInterpret)

--- a/src/make_interpret.jl
+++ b/src/make_interpret.jl
@@ -13,6 +13,9 @@ A tag is treated as an *input terminal* if:
 _is_input_tag(tag, input_set) =
     tag isa Symbol && (occursin("_arg_", String(tag)) || (input_set !== nothing && (tag in input_set)))
 
+_contains_input_tag(rule, input_set) = _is_input_tag(rule, input_set) || (rule isa Expr && any(arg -> _contains_input_tag(arg, input_set), rule.args))
+
+
 
 """
     _qualify(target_module::Module, f)
@@ -220,7 +223,10 @@ end
 
 struct GeneratedOutputInterpreter{F}
     core::F
+    arg_rules::Vector{Bool}
 end
+
+is_constant(rule, arg_rules, children_outputs) = !arg_rules[rule] && all(cs -> all(c -> c ===(first(cs)), cs), children_outputs)
 
 # Single input
 function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
@@ -229,7 +235,7 @@ function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
 end
 
 function (gi::GeneratedOutputInterpreter)(rule::Int,
-                                   children_outputs::AbstractVector{<:Any},
+                                   children_outputs,
                                    input::AbstractDict{Symbol,Any})
     return gi.core(gi.core, rule, children_outputs, input)
 end
@@ -241,8 +247,13 @@ function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
 end
 
 function (gi::GeneratedOutputInterpreter)(rule::Int,
-                                   children_outputs::AbstractVector{<:AbstractVector{<:Any}},
+                                   children_outputs,
                                    inputs::AbstractVector{<:AbstractDict{Symbol,Any}})
+    if is_constant(rule, gi.arg_rules, children_outputs)
+        res = gi.core(gi.core, rule, [first(outputs) for outputs in children_outputs], first(inputs))
+        return [res for _ in inputs]
+    end
+
     return [gi.core(gi.core, rule, [outputs[index] for outputs in children_outputs], input) for (index, input) in enumerate(inputs)]
 end
 
@@ -252,7 +263,7 @@ function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
 end
 
 function (gi::GeneratedOutputInterpreter)(rule::Int,
-                                   children_outputs::AbstractVector{<:Any},
+                                   children_outputs,
                                    ex::HerbSpecification.IOExample)
     return gi(rule, children_outputs, ex.in)
 end
@@ -263,8 +274,13 @@ function (gi::GeneratedInterpreter)(prog::HerbCore.AbstractRuleNode,
 end
 
 function (gi::GeneratedOutputInterpreter)(rule::Int,
-                                   children_outputs::AbstractVector{<:AbstractVector{<:Any}},
+                                   children_outputs,
                                    exs::AbstractVector{<:HerbSpecification.IOExample})
+    if is_constant(rule, gi.arg_rules, children_outputs)
+        res = gi(rule, [first(outputs) for outputs in children_outputs], first(exs))
+        return [res for _ in exs]
+    end
+
     return [gi(rule, [outputs[index] for outputs in children_outputs], ex) for (index, ex) in enumerate(exs)]
 end
 
@@ -362,9 +378,14 @@ function make_output_interpreter(grammar::AbstractGrammar;
     end)
     Base.remove_linenums!(ex)
 
+    # Obtain which rules are argument rules
+    input_set = input_symbols === nothing ? nothing : Set(input_symbols)
+    arg_rules = [_contains_input_tag(rule, input_set) for rule in grammar.rules]
+
+
     # Call RuntimeGeneratedFunction on this, so we can directly use it
     core = RuntimeGeneratedFunctions.RuntimeGeneratedFunction(cache_module, target_module, ex)
-    return GeneratedOutputInterpreter(core)
+    return GeneratedOutputInterpreter(core, arg_rules)
 end
 
 

--- a/test/test_make_interpreter.jl
+++ b/test/test_make_interpreter.jl
@@ -286,4 +286,68 @@ end
         @test interpret_custom(rn, input(1)) == 3
         @test isnothing(interpret_custom(rn, input(0)))
     end
+
+    @testset "Test make_output_interpreter" begin
+        g = @cfgrammar begin
+            Number = |(1:2)             # 1, 2
+            Number = x                  # 3
+            Number = Number + Number    # 4
+            Number = Number * Number    # 5
+            Number = Number + 1         # 6
+            Number = x * 2              # 7
+        end
+
+        # Compile once
+        interpret_custom = HerbInterpret.make_output_interpreter(g; input_symbols=[:x])
+
+        @testset "Single input dict" begin
+            input = Dict{Symbol,Any}(:x => 5)
+            @test interpret_custom(1, [], input) == 1
+            @test interpret_custom(2, [], input) == 2
+            @test interpret_custom(3, [], input) == 5
+            @test interpret_custom(4, [1, 2], input) == 3
+            @test interpret_custom(5, [1, 2], input) == 2
+            @test interpret_custom(6, [1], input) == 2
+            @test interpret_custom(7, [], input) == 10
+        end
+
+        @testset "Vector of input dicts" begin
+            inputs = [
+                Dict{Symbol,Any}(:x => 1),
+                Dict{Symbol,Any}(:x => 3),
+            ]
+            @test interpret_custom(1, [[],[]], inputs) == [1,1]
+            @test interpret_custom(2, [[],[]], inputs) == [2,2]
+            @test interpret_custom(3, [[],[]], inputs) == [1,3]
+            @test interpret_custom(4, [[1,2], [3,4]], inputs) == [3,7]
+            @test interpret_custom(5, [[1,2], [3,4]], inputs) == [2,12]
+            @test interpret_custom(6, [[1],[2]], inputs) == [2,3]
+            @test interpret_custom(7, [[],[]], inputs) == [2,6]
+        end
+
+        @testset "Single IOExample" begin
+            ex = HerbSpecification.IOExample(Dict{Symbol,Any}(:x => 5), nothing)
+            @test interpret_custom(1, [], ex) == 1
+            @test interpret_custom(2, [], ex) == 2
+            @test interpret_custom(3, [], ex) == 5
+            @test interpret_custom(4, [1, 2], ex) == 3
+            @test interpret_custom(5, [1, 2], ex) == 2
+            @test interpret_custom(6, [1], ex) == 2
+            @test interpret_custom(7, [], ex) == 10
+        end
+
+        @testset "Vector of IOExamples" begin
+            exs = [
+                HerbSpecification.IOExample(Dict{Symbol,Any}(:x => 1), nothing),
+                HerbSpecification.IOExample(Dict{Symbol,Any}(:x => 3), nothing),
+            ]
+            @test interpret_custom(1, [[],[]], exs) == [1,1]
+            @test interpret_custom(2, [[],[]], exs) == [2,2]
+            @test interpret_custom(3, [[],[]], exs) == [1,3]
+            @test interpret_custom(4, [[1,2], [3,4]], exs) == [3,7]
+            @test interpret_custom(5, [[1,2], [3,4]], exs) == [2,12]
+            @test interpret_custom(6, [[1],[2]], exs) == [2,3]
+            @test interpret_custom(7, [[],[]], exs) == [2,6]
+        end
+    end
 end

--- a/test/test_make_interpreter.jl
+++ b/test/test_make_interpreter.jl
@@ -316,13 +316,13 @@ end
                 Dict{Symbol,Any}(:x => 1),
                 Dict{Symbol,Any}(:x => 3),
             ]
-            @test interpret_custom(1, [[],[]], inputs) == [1,1]
-            @test interpret_custom(2, [[],[]], inputs) == [2,2]
-            @test interpret_custom(3, [[],[]], inputs) == [1,3]
-            @test interpret_custom(4, [[1,2], [3,4]], inputs) == [3,7]
-            @test interpret_custom(5, [[1,2], [3,4]], inputs) == [2,12]
-            @test interpret_custom(6, [[1],[2]], inputs) == [2,3]
-            @test interpret_custom(7, [[],[]], inputs) == [2,6]
+            @test interpret_custom(1, Vector[], inputs) == [1,1]
+            @test interpret_custom(2, Vector[], inputs) == [2,2]
+            @test interpret_custom(3, Vector[], inputs) == [1,3]
+            @test interpret_custom(4, [[1,2], [3,4]], inputs) == [4,6]
+            @test interpret_custom(5, [[1,2], [3,4]], inputs) == [3,8]
+            @test interpret_custom(6, [[1,2]], inputs) == [2,3]
+            @test interpret_custom(7, Vector[], inputs) == [2,6]
         end
 
         @testset "Single IOExample" begin
@@ -341,17 +341,13 @@ end
                 HerbSpecification.IOExample(Dict{Symbol,Any}(:x => 1), nothing),
                 HerbSpecification.IOExample(Dict{Symbol,Any}(:x => 3), nothing),
             ]
-            @test interpret_custom(1, [[],[]], exs) == [1,1]
             @test interpret_custom(1, Vector[], exs) == [1,1]
-            @test interpret_custom(2, [[],[]], exs) == [2,2]
             @test interpret_custom(2, Vector[], exs) == [2,2]
-            @test interpret_custom(3, [[],[]], exs) == [1,3]
-            @test interpret_custom(3, Vector[], exs) == [1,3]
-            @test interpret_custom(4, [[1,2], [3,4]], exs) == [3,7]
-            @test interpret_custom(5, [[1,2], [3,4]], exs) == [2,12]
-            @test interpret_custom(6, [[1],[2]], exs) == [2,3]
-            @test interpret_custom(7, [[],[]], exs) == [2,6]
-            @test interpret_custom(7, Vector[], exs) == [2,6]
+            @test interpret_custom(3, Vector[], exs) == [1,3] #
+            @test interpret_custom(4, [[1,2], [3,4]], exs) == [4,6]
+            @test interpret_custom(5, [[1,2], [3,4]], exs) == [3,8]
+            @test interpret_custom(6, [[1,2]], exs) == [2,3]
+            @test interpret_custom(7, Vector[], exs) == [2,6] #
         end
     end
 end

--- a/test/test_make_interpreter.jl
+++ b/test/test_make_interpreter.jl
@@ -342,16 +342,16 @@ end
                 HerbSpecification.IOExample(Dict{Symbol,Any}(:x => 3), nothing),
             ]
             @test interpret_custom(1, [[],[]], exs) == [1,1]
-            @test interpret_custom(1, [], exs) == [1,1]
+            @test interpret_custom(1, Vector[], exs) == [1,1]
             @test interpret_custom(2, [[],[]], exs) == [2,2]
-            @test interpret_custom(2, [], exs) == [2,2]
+            @test interpret_custom(2, Vector[], exs) == [2,2]
             @test interpret_custom(3, [[],[]], exs) == [1,3]
-            @test interpret_custom(3, [], exs) == [1,3]
+            @test interpret_custom(3, Vector[], exs) == [1,3]
             @test interpret_custom(4, [[1,2], [3,4]], exs) == [3,7]
             @test interpret_custom(5, [[1,2], [3,4]], exs) == [2,12]
             @test interpret_custom(6, [[1],[2]], exs) == [2,3]
             @test interpret_custom(7, [[],[]], exs) == [2,6]
-            @test interpret_custom(7, [], exs) == [2,6]
+            @test interpret_custom(7, Vector[], exs) == [2,6]
         end
     end
 end

--- a/test/test_make_interpreter.jl
+++ b/test/test_make_interpreter.jl
@@ -342,12 +342,16 @@ end
                 HerbSpecification.IOExample(Dict{Symbol,Any}(:x => 3), nothing),
             ]
             @test interpret_custom(1, [[],[]], exs) == [1,1]
+            @test interpret_custom(1, [], exs) == [1,1]
             @test interpret_custom(2, [[],[]], exs) == [2,2]
+            @test interpret_custom(2, [], exs) == [2,2]
             @test interpret_custom(3, [[],[]], exs) == [1,3]
+            @test interpret_custom(3, [], exs) == [1,3]
             @test interpret_custom(4, [[1,2], [3,4]], exs) == [3,7]
             @test interpret_custom(5, [[1,2], [3,4]], exs) == [2,12]
             @test interpret_custom(6, [[1],[2]], exs) == [2,3]
             @test interpret_custom(7, [[],[]], exs) == [2,6]
+            @test interpret_custom(7, [], exs) == [2,6]
         end
     end
 end

--- a/test/test_make_interpreter.jl
+++ b/test/test_make_interpreter.jl
@@ -70,6 +70,15 @@ module LocalStateDSL3
     end
 end
 
+module SafeDiv
+    using HerbCore
+    using HerbGrammar
+    using RuntimeGeneratedFunctions
+    RuntimeGeneratedFunctions.init(SafeDiv)
+
+    safe_div(a, b) = b == 0 ? nothing : a / b
+end
+
 
 @testset verbose=true "Test make_interpreter" begin
     @testset "Test base functionality" begin
@@ -253,5 +262,28 @@ end
             outs = interp3(prog_while, [LocalStateDSL3.St(0), LocalStateDSL3.St(1), LocalStateDSL3.St(3)])
             @test outs == [LocalStateDSL3.St(3), LocalStateDSL3.St(3), LocalStateDSL3.St(3)]
         end
+    end
+
+    @testset "Functions returning nothing" begin
+        g = @cfgrammar begin
+            Number = |(1:2)
+            Number = x
+            Number = Number + Number
+            Number = Number * Number
+            Number = Number + 1
+            Number = x * 2
+            Number = safe_div(Number, Number)
+        end
+
+        # Compile once
+        interpret_custom = HerbInterpret.make_interpreter(g; input_symbols=[:x], target_module=SafeDiv)
+
+
+        rn = @rulenode(4{1,8{2,3}})  # 1 + 2 / x
+        input = x -> Dict{Symbol,Any}(:x => x)
+
+        @test interpret_custom(rn, input(2)) == 2
+        @test interpret_custom(rn, input(1)) == 3
+        @test isnothing(interpret_custom(rn, input(0)))
     end
 end

--- a/test/test_make_interpreter.jl
+++ b/test/test_make_interpreter.jl
@@ -545,4 +545,28 @@ inc(x) = x + 1
             @test interpret_custom(7, Vector[], exs) == [2,6] #
         end
     end
+
+    @testset "Test constants memory optimization" begin
+        g = @cfgrammar begin
+            Array = [1,2,3]
+            Array = [3,2,1]
+            Array = Array + Array
+        end
+
+        interpret_custom = HerbInterpret.make_output_interpreter(g)
+
+        inputs = [
+            Dict{Symbol,Any}(),
+            Dict{Symbol,Any}(),
+        ]
+
+        os1 = interpret_custom(1, Vector[], inputs)
+        os2 = interpret_custom(2, Vector[], inputs)
+        os3 = interpret_custom(3, [os1, os2], inputs)
+        
+        @test os1[1] === os1[2]
+        @test os2[1] === os2[2]
+        @test os3[1] === os3[2]
+    end
+    
 end

--- a/test/test_make_interpreter.jl
+++ b/test/test_make_interpreter.jl
@@ -35,6 +35,8 @@ module LocalStateDSL2
         x::Int
     end
 
+    Base.:(==)(a::St, b::St) = a.x == b.x
+
     inc(st::St) = St(st.x + 1)
     dec(st::St) = St(st.x - 1)
     iseven(st::St) = Base.iseven(st.x)
@@ -44,6 +46,7 @@ module LocalStateDSL2
         Step  = IF(Cond, Step, Step)
         Step  = inc()
         Step  = dec()
+        Step  = (Step; Step)
         Cond  = iseven()
     end
 end
@@ -69,6 +72,49 @@ module LocalStateDSL3
         Cond  = lt3()
     end
 end
+
+module LocalStateDSL4
+    using HerbCore
+    using HerbGrammar
+    using RuntimeGeneratedFunctions
+    RuntimeGeneratedFunctions.init(@__MODULE__)
+
+    g4 = @cfgrammar begin
+        Start = Step
+        Step  = apply(Func)
+        Step  = IF(Cond, Step, Step)
+        Step  = inc()
+        Step  = dec()
+        Cond  = iseven()
+
+        Func  = plus1
+        Func  = x -> double(x)
+        Func  = x -> x + 1
+        Func  = x -> double(Func(x)) + 1
+        Func  = x -> Func(Func(x))
+    end
+
+    struct St
+        x::Int
+    end
+
+    Base.:(==)(a::St, b::St) = a.x == b.x
+
+    # stateful primitives
+    inc(st::St) = St(st.x + 1)
+    dec(st::St) = St(st.x - 1)
+    iseven(st::St) = Base.iseven(st.x)
+
+    # higher-order stateful primitive:
+    # apply a synthesized function to the integer inside the state
+    apply(f, st::St) = St(f(st.x))
+
+    # pure helpers for synthesized lambdas
+    plus1(x::Int) = x + 1
+    double(x::Int) = 2 * x
+end
+
+inc(x) = x + 1
 
 
 @testset verbose=true "Test make_interpreter" begin
@@ -127,6 +173,88 @@ end
             ]
             outs = interpret_custom(rn, exs)
             @test outs == [6, 30]
+        end
+    end
+
+    @testset "Synthesized lambda values" begin
+        @testset "Base case" begin
+            g = @csgrammar begin
+                Arr = _arg_1
+                Arr = map(Lambda, Arr)
+
+                Lambda = x -> Func(x)
+
+                Func = iseven
+                Func = isodd
+                Func = y -> y + 1
+                Func = y -> y * 2
+            end
+
+            interpret_custom = HerbInterpret.make_interpreter(g)
+
+            input = Dict{Symbol,Any}(:_arg_1 => [1, 2, 3, 4])
+
+            # Arr = _arg_1
+            @test interpret_custom(@rulenode(1), input) == [1, 2, 3, 4]
+
+            # Arr = map(Lambda, Arr), Lambda = x -> iseven(x)
+            @test interpret_custom(@rulenode(2{3{4},1}), input) == [false, true, false, true]
+
+            # Arr = map(Lambda, Arr), Lambda = x -> isodd(x)
+            @test interpret_custom(@rulenode(2{3{5},1}), input) == [true, false, true, false]
+
+            # Arr = map(Lambda, Arr), Lambda = x -> (y -> y + 1)(x)
+            @test interpret_custom(@rulenode(2{3{6},1}), input) == [2, 3, 4, 5]
+
+            # Arr = map(Lambda, Arr), Lambda = x -> (y -> y * 2)(x)
+            @test interpret_custom(@rulenode(2{3{7},1}), input) == [2, 4, 6, 8]
+        end
+
+        @testset "Synthesized function composition" begin
+            g = @csgrammar begin
+                Arr = _arg_1
+                Arr = map(Func, Arr)
+
+                Func = inc
+                Func = x -> 2*x
+                Func = x -> x + 1
+                Func = x -> 2*Func(x) + 1
+                Func = x -> Func(Func(x))
+            end
+
+            interpret_custom = HerbInterpret.make_interpreter(
+                g;
+                target_module=@__MODULE__,
+            )
+
+            input = Dict{Symbol,Any}(:_arg_1 => [1, 2, 3, 4])
+
+            # identity on arrays
+            @test interpret_custom(@rulenode(1), input) == [1, 2, 3, 4]
+
+            # map(inc, arr)
+            @test interpret_custom(@rulenode(2{3,1}), input) == [2, 3, 4, 5]
+
+            # map(x -> 2*x, arr)
+            @test interpret_custom(@rulenode(2{4,1}), input) == [2, 4, 6, 8]
+
+            # map(x -> x + 1, arr)
+            @test interpret_custom(@rulenode(2{5,1}), input) == [2, 3, 4, 5]
+
+            # map(x -> 2*inc(x) + 1, arr)
+            @test interpret_custom(@rulenode(2{6{3},1}), input) == [5, 7, 9, 11]
+
+            # map(x -> (x -> 2*x)(inc(x)), arr) = map(x -> 2*inc(x), arr)
+            @test interpret_custom(@rulenode(2{7{4,3},1}), input) == [4, 6, 8, 10]
+
+            # map(x -> inc(2*x), arr)
+            @test interpret_custom(@rulenode(2{7{3,4},1}), input) == [3, 5, 7, 9]
+
+            # nested composition:
+            # outer = x -> 2*inc(x) + 1
+            # inner = x -> x + 1
+            # result = x -> 2*inc(x+1) + 1 = 2x + 5
+            @test interpret_custom(@rulenode(2{7{6{3},5},1}), input) == [7, 9, 11, 13]
         end
     end
 
@@ -199,7 +327,7 @@ end
             @test outs == [LocalStateDSL.St(2), LocalStateDSL.St(12)]
         end
 
-        @testset "IF semantics in external target module" begin
+        @testset "IF and sequencing semantics in external target module" begin
             # Build interpreter from grammar that lives in LocalStateDSL2
             interp2 = HerbInterpret.make_stateful_interpreter(
                 LocalStateDSL2.g2;
@@ -208,17 +336,35 @@ end
             )
 
             # Rule indices in LocalStateDSL2.g2:
-            # 1 Start=Step
-            # 2 Step=IF(Cond,Step,Step)
-            # 3 Step=inc()
-            # 4 Step=dec()
-            # 5 Cond=iseven()
+            # 1 Start = Step
+            # 2 Step  = IF(Cond, Step, Step)
+            # 3 Step  = inc()
+            # 4 Step  = dec()
+            # 5 Step  = (Step; Step)
+            # 6 Cond  = iseven()
 
             # IF(iseven(), inc(), dec())
-            prog_if = @rulenode(2{5,3,4})
+            prog_if = @rulenode(2{6,3,4})
 
             @test interp2(prog_if, LocalStateDSL2.St(2)) == LocalStateDSL2.St(3)  # even -> inc
             @test interp2(prog_if, LocalStateDSL2.St(3)) == LocalStateDSL2.St(2)  # odd  -> dec
+
+            # (inc(); inc())
+            prog_two_incs = @rulenode(5{3,3})
+            @test interp2(prog_two_incs, LocalStateDSL2.St(0)) == LocalStateDSL2.St(2)
+
+            # (inc(); dec())
+            prog_inc_dec = @rulenode(5{3,4})
+            @test interp2(prog_inc_dec, LocalStateDSL2.St(10)) == LocalStateDSL2.St(10)
+
+            # (IF(iseven(), inc(), dec()); inc())
+            prog_if_then_inc = @rulenode(5{2{6,3,4},3})
+            @test interp2(prog_if_then_inc, LocalStateDSL2.St(2)) == LocalStateDSL2.St(4)  # 2 -> inc -> 3 -> inc -> 4
+            @test interp2(prog_if_then_inc, LocalStateDSL2.St(3)) == LocalStateDSL2.St(3)  # 3 -> dec -> 2 -> inc -> 3
+
+            # Vector-of-states overload
+            outs_vec = interp2(prog_two_incs, [LocalStateDSL2.St(0), LocalStateDSL2.St(10)])
+            @test outs_vec == [LocalStateDSL2.St(2), LocalStateDSL2.St(12)]
 
             # IOExample support (state is in :_arg_1)
             exs = [
@@ -228,6 +374,14 @@ end
 
             outs_ex = interp2(prog_if, exs)
             @test outs_ex == [LocalStateDSL2.St(3), LocalStateDSL2.St(2)]
+
+            exs_seq = [
+                HerbSpecification.IOExample(Dict{Symbol,Any}(:_arg_1 => LocalStateDSL2.St(0)), nothing),
+                HerbSpecification.IOExample(Dict{Symbol,Any}(:_arg_1 => LocalStateDSL2.St(5)), nothing),
+            ]
+
+            outs_ex_seq = interp2(prog_two_incs, exs_seq)
+            @test outs_ex_seq == [LocalStateDSL2.St(2), LocalStateDSL2.St(7)]
         end
 
         @testset "WHILE operator (bounded loop) " begin
@@ -252,6 +406,47 @@ end
             # Vector-of-states
             outs = interp3(prog_while, [LocalStateDSL3.St(0), LocalStateDSL3.St(1), LocalStateDSL3.St(3)])
             @test outs == [LocalStateDSL3.St(3), LocalStateDSL3.St(3), LocalStateDSL3.St(3)]
+        end
+
+        @testset "Stateful interpreter with synthesized lambdas in external module" begin
+            interp = HerbInterpret.make_stateful_interpreter(
+                LocalStateDSL4.g4;
+                target_module = LocalStateDSL4,
+                cache_module  = LocalStateDSL4,
+            )
+
+            # apply(plus1)
+            prog_plus1 = @rulenode(1{2{7}})
+            @test interp(prog_plus1, LocalStateDSL4.St(1)) == LocalStateDSL4.St(2)
+
+            # apply(x -> double(x))
+            prog_double = @rulenode(1{2{8}})
+            @test interp(prog_double, LocalStateDSL4.St(3)) == LocalStateDSL4.St(6)
+
+            # apply(x -> x + 1)
+            prog_lambda_plus1 = @rulenode(1{2{9}})
+            @test interp(prog_lambda_plus1, LocalStateDSL4.St(3)) == LocalStateDSL4.St(4)
+
+            # apply(x -> double(plus1(x)) + 1)
+            prog_nested = @rulenode(1{2{10{7}}})
+            @test interp(prog_nested, LocalStateDSL4.St(3)) == LocalStateDSL4.St(9)
+
+            # apply(x -> double(plus1(x)))
+            prog_comp1 = @rulenode(1{2{11{8,7}}})
+            @test interp(prog_comp1, LocalStateDSL4.St(3)) == LocalStateDSL4.St(8)
+
+            # apply(x -> plus1(double(x)))
+            prog_comp2 = @rulenode(1{2{11{7,8}}})
+            @test interp(prog_comp2, LocalStateDSL4.St(3)) == LocalStateDSL4.St(7)
+
+            # IF(iseven(), apply(plus1), dec())
+            prog_if = @rulenode(1{3{6,2{7},5}})
+            @test interp(prog_if, LocalStateDSL4.St(2)) == LocalStateDSL4.St(3)
+            @test interp(prog_if, LocalStateDSL4.St(3)) == LocalStateDSL4.St(2)
+
+            # vector-of-states overload
+            outs = interp(prog_nested, [LocalStateDSL4.St(0), LocalStateDSL4.St(5)])
+            @test outs == [LocalStateDSL4.St(3), LocalStateDSL4.St(13)]
         end
     end
 end


### PR DESCRIPTION
Exception throwing and catching in Julia is really really slow. A better way to handle invalid arguments or parsing is to let domain functions return a special value in stead of throwing exceptions. I choose `nothing` as an exception, but we might use more informative exceptions.

To correctly pass exceptions upstream, the interpreter needs to return `nothing` if any child of the interpreted program produces `nothing`. 

To give a sense of the speed-up this might give; a certain SyGuS string problem was solved in ±12s using the old interpreter, but with this fix it only took ±1s. This is a huge speedup, but the string domain is exception heavy. I don't think fix will harm performance in any other way.